### PR TITLE
BugFix: http.method is always PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ with context.new_entry_span(op='https://github.com/apache') as span:
 # the span automatically stops when exiting the `with` context
 
 with context.new_exit_span(op='https://github.com/apache', peer='localhost:8080') as span:
-    span.component = Component.Http
+    span.component = Component.Flask
 
 with context.new_local_span(op='https://github.com/apache') as span:
     span.tag(Tag(key='Singer', val='Nakajima'))
@@ -92,7 +92,7 @@ def some_method():
 
 context: SpanContext = get_context()
 with context.new_entry_span(op=str('https://github.com/apache/skywalking')) as span:
-    span.component = Component.Http
+    span.component = Component.Flask
     some_method()
 ```
 

--- a/skywalking/__init__.py
+++ b/skywalking/__init__.py
@@ -27,7 +27,7 @@ loggings.init()
 
 class Component(Enum):
     Unknown = 0
-    Http = 49
+    General = 7000  # built-in modules that may not have a logo to display
     Flask = 7001
 
 

--- a/skywalking/plugins/sw_request/__init__.py
+++ b/skywalking/plugins/sw_request/__init__.py
@@ -35,9 +35,9 @@ def install():
 
         def _sw_open(this: OpenerDirector, fullurl, data, timeout):
             context = get_context()
-            with context.new_exit_span(op=fullurl.selector, peer=fullurl.host) as span:
+            with context.new_exit_span(op=fullurl.selector or '/', peer=fullurl.host) as span:
                 span.layer = Layer.Http
-                span.component = Component.Http
+                span.component = Component.General
                 try:
                     res = _open(this, fullurl, data, timeout)
                     span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))

--- a/tests/main.py
+++ b/tests/main.py
@@ -36,26 +36,26 @@ if __name__ == '__main__':
     for _ in range(1, 20):
         context = get_context()  # type: SpanContext
         with context.new_entry_span(op='https://github.com/1') as s1:
-            s1.component = Component.Http
+            s1.component = Component.General
             some_method()
             print(s1)
             with context.new_entry_span(op='https://github.com/2') as s2:
-                s2.component = Component.Http
+                s2.component = Component.General
                 s2.layer = Layer.Http
                 print(s2)
                 sleep(0.5)
                 with context.new_exit_span(op='https://github.com/3', peer='127.0.0.1:80') as s3:
-                    s3.component = Component.Http
+                    s3.component = Component.General
                     s3.layer = Layer.Http
                     print(s3)
                     sleep(0.5)
                     with context.new_entry_span(op='https://github.com/4') as s4:
-                        s4.component = Component.Http
+                        s4.component = Component.General
                         s4.layer = Layer.Http
                         print(s4)
                         sleep(0.5)
                 with context.new_exit_span(op='https://github.com/5', peer='127.0.0.1:80') as s5:
-                    s5.component = Component.Http
+                    s5.component = Component.General
                     s5.layer = Layer.Http
                     print(s5)
                     sleep(0.5)


### PR DESCRIPTION
- Set operation name `/` when the url is just a domain name
- Rename component `Http` to `General`