### PR TITLE
Polish the test framework for simplicity of local test

### DIFF
--- a/tests/plugin/docker/docker-compose.base.yml
+++ b/tests/plugin/docker/docker-compose.base.yml
@@ -15,28 +15,31 @@
 # limitations under the License.
 #
 
-import time
+version: '2.1'
 
-from skywalking import agent, config
+services:
+  collector:
+    build:
+      context: .
+      dockerfile: Dockerfile.tool
+    ports:
+      - 19876:19876
+      - 12800:12800
+    networks:
+      - beyond
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
 
-if __name__ == '__main__':
-    config.service_name = 'provider'
-    agent.start()
-
-    import socketserver
-    from http.server import BaseHTTPRequestHandler
-
-    class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
-
-        def do_POST(self):
-            time.sleep(0.5)
-            self.send_response(200)
-            self.send_header('Content-Type', 'application/json')
-            self.end_headers()
-            self.wfile.write('{"song": "Despacito", "artist": "Luis Fonsi"}'.encode('ascii'))
-
-    PORT = 9091
-    Handler = SimpleHTTPRequestHandler
-
-    with socketserver.TCPServer(("", PORT), Handler) as httpd:
-        httpd.serve_forever()
+  agent:
+    build:
+      context: ../../../
+      dockerfile: tests/plugin/docker/Dockerfile.agent
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
+      SW_AGENT_LOGGING_LEVEL: DEBUG
+    networks:
+      - beyond
+    command: ['python3', '/entrypoint.py']

--- a/tests/plugin/sw_http/docker-compose.yml
+++ b/tests/plugin/sw_http/docker-compose.yml
@@ -19,33 +19,18 @@ version: '2.1'
 
 services:
   collector:
-    build:
-      context: ../docker
-      dockerfile: Dockerfile.tool
-    ports:
-      - 19876:19876
-      - 12800:12800
-    networks:
-      - beyond
-    healthcheck:
-      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800"]
-      interval: 5s
-      timeout: 60s
-      retries: 120
+    extends:
+      service: collector
+      file: ../docker/docker-compose.base.yml
 
   provider:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9091:9091
     volumes:
-      - ./services/provider.py:/app/provider.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/provider.py']
+      - ./services/provider.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy
@@ -56,18 +41,13 @@ services:
       retries: 120
 
   consumer:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9090:9090
     volumes:
-      - ./services/consumer.py:/app/consumer.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/consumer.py']
+      - ./services/consumer.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy

--- a/tests/plugin/sw_http/services/consumer.py
+++ b/tests/plugin/sw_http/services/consumer.py
@@ -21,7 +21,6 @@ from skywalking import agent, config
 
 if __name__ == '__main__':
     config.service_name = 'consumer'
-    config.logging_level = 'DEBUG'
     agent.start()
 
     import socketserver

--- a/tests/plugin/sw_http/test_http.py
+++ b/tests/plugin/sw_http/test_http.py
@@ -26,7 +26,7 @@ from testcontainers.compose import DockerCompose
 from tests.plugin import BasePluginTest
 
 
-class TestRequestPlugin(BasePluginTest):
+class TestPlugin(BasePluginTest):
     @classmethod
     def setUpClass(cls):
         cls.compose = DockerCompose(filepath=dirname(abspath(__file__)))

--- a/tests/plugin/sw_http_wsgi/docker-compose.yml
+++ b/tests/plugin/sw_http_wsgi/docker-compose.yml
@@ -19,33 +19,18 @@ version: '2.1'
 
 services:
   collector:
-    build:
-      context: ../docker
-      dockerfile: Dockerfile.tool
-    ports:
-      - 19876:19876
-      - 12800:12800
-    networks:
-      - beyond
-    healthcheck:
-      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800"]
-      interval: 5s
-      timeout: 60s
-      retries: 120
+    extends:
+      service: collector
+      file: ../docker/docker-compose.base.yml
 
   provider:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9091:9091
     volumes:
-      - ./services/provider.py:/app/provider.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/provider.py']
+      - ./services/provider.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy
@@ -56,18 +41,13 @@ services:
       retries: 120
 
   consumer:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9090:9090
     volumes:
-      - ./services/consumer.py:/app/consumer.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/consumer.py']
+      - ./services/consumer.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy

--- a/tests/plugin/sw_http_wsgi/services/consumer.py
+++ b/tests/plugin/sw_http_wsgi/services/consumer.py
@@ -21,7 +21,6 @@ from skywalking import agent, config
 
 if __name__ == '__main__':
     config.service_name = 'consumer'
-    config.logging_level = 'DEBUG'
     agent.start()
 
     import socketserver

--- a/tests/plugin/sw_http_wsgi/services/provider.py
+++ b/tests/plugin/sw_http_wsgi/services/provider.py
@@ -21,7 +21,6 @@ from skywalking import agent, config
 
 if __name__ == '__main__':
     config.service_name = 'provider'
-    config.logging_level = 'DEBUG'
     agent.start()
 
     from werkzeug import Request, Response

--- a/tests/plugin/sw_http_wsgi/test_http_wsgi.py
+++ b/tests/plugin/sw_http_wsgi/test_http_wsgi.py
@@ -26,7 +26,7 @@ from testcontainers.compose import DockerCompose
 from tests.plugin import BasePluginTest
 
 
-class TestRequestPlugin(BasePluginTest):
+class TestPlugin(BasePluginTest):
     @classmethod
     def setUpClass(cls):
         cls.compose = DockerCompose(filepath=dirname(abspath(__file__)))

--- a/tests/plugin/sw_requests/docker-compose.yml
+++ b/tests/plugin/sw_requests/docker-compose.yml
@@ -19,33 +19,18 @@ version: '2.1'
 
 services:
   collector:
-    build:
-      context: ../docker
-      dockerfile: Dockerfile.tool
-    ports:
-      - 19876:19876
-      - 12800:12800
-    networks:
-      - beyond
-    healthcheck:
-      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800"]
-      interval: 5s
-      timeout: 60s
-      retries: 120
+    extends:
+      service: collector
+      file: ../docker/docker-compose.base.yml
 
   provider:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9091:9091
     volumes:
-      - ./services/provider.py:/app/provider.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/provider.py']
+      - ./services/provider.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy
@@ -56,18 +41,13 @@ services:
       retries: 120
 
   consumer:
-    build:
-      context: ../../../
-      dockerfile: tests/plugin/docker/Dockerfile.agent
-    networks:
-      - beyond
+    extends:
+      service: agent
+      file: ../docker/docker-compose.base.yml
     ports:
       - 9090:9090
     volumes:
-      - ./services/consumer.py:/app/consumer.py
-    environment:
-      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
-    command: ['python3', '/app/consumer.py']
+      - ./services/consumer.py:/entrypoint.py
     depends_on:
       collector:
         condition: service_healthy

--- a/tests/plugin/sw_requests/services/consumer.py
+++ b/tests/plugin/sw_requests/services/consumer.py
@@ -21,7 +21,6 @@ from skywalking import agent, config
 
 if __name__ == '__main__':
     config.service_name = 'consumer'
-    config.logging_level = 'DEBUG'
     agent.start()
 
     import socketserver

--- a/tests/plugin/sw_requests/services/provider.py
+++ b/tests/plugin/sw_requests/services/provider.py
@@ -21,7 +21,6 @@ from skywalking import agent, config
 
 if __name__ == '__main__':
     config.service_name = 'provider'
-    config.logging_level = 'DEBUG'
     agent.start()
 
     import socketserver

--- a/tests/plugin/sw_requests/test_request.py
+++ b/tests/plugin/sw_requests/test_request.py
@@ -26,7 +26,7 @@ from testcontainers.compose import DockerCompose
 from tests.plugin import BasePluginTest
 
 
-class TestRequestPlugin(BasePluginTest):
+class TestPlugin(BasePluginTest):
     @classmethod
     def setUpClass(cls):
         cls.compose = DockerCompose(filepath=dirname(abspath(__file__)))


### PR DESCRIPTION

- Extract as many commonly-used codes as possible
- Rename the test class to a more general one as contributors tend to copy-paste w/o modifying the class name