### PR TITLE
Test: print the diff list when validation failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     extras_require={
         "test": [
             "testcontainers",
+            "pyyaml",
             "Werkzeug",
             "pymysql",
             "redis",


### PR DESCRIPTION
This patch makes it more convenient for the developers when running tests locally and the tests failed

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15965696/87958515-36dc8f80-cae4-11ea-8b4b-cb4ce07fcbe8.png">
