### PR TITLE
[Core][Bug] Move generated packages into skywalking namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 /apache_skywalking.egg-info/
 **/venv/
 tests/**/requirements.txt
+skywalking/protocol

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include browser/*.py
-include common/*.py
-include language_agent/*.py
-include management/*.py
-include profile/*.py
-include service_mesh_probe/*.py

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,7 @@ setup-test: setup
 
 gen:
 	python3 -m grpc_tools.protoc --version || python3 -m pip install grpcio-tools
-	python3 -m grpc_tools.protoc -I protocol --python_out=. --grpc_python_out=. protocol/**/*.proto
-	touch browser/__init__.py
-	touch common/__init__.py
-	touch language_agent/__init__.py
-	touch management/__init__.py
-	touch profile/__init__.py
-	touch service_mesh_probe/__init__.py
+	python3 tools/codegen.py
 
 lint: clean
 	flake8 --version || python3 -m pip install flake8
@@ -59,10 +53,11 @@ upload: package
 	twine upload dist/*
 
 clean:
-	rm -rf browser common language_agent management profile service_mesh_probe
-	rm -rf skywalking_python.egg-info dist build
+	rm -rf skywalking/protocol
+	rm -rf apache_skywalking.egg-info dist build
 	rm -rf skywalking-python*.tgz*
 	find . -name "__pycache__" -exec rm -r {} +
+	find . -name ".pytest_cache" -exec rm -r {} +
 	find . -name "*.pyc" -exec rm -r {} +
 
 release: clean lint license

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -20,12 +20,12 @@ from queue import Queue
 
 import grpc
 
-from common.Common_pb2 import KeyStringValuePair
-from language_agent.Tracing_pb2 import SegmentObject, SpanObject, Log, SegmentReference
 from skywalking import config
 from skywalking.agent import Protocol
 from skywalking.agent.protocol.interceptors import header_adder_interceptor
 from skywalking.client.grpc import GrpcServiceManagementClient, GrpcTraceSegmentReportService
+from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
+from skywalking.protocol.language_agent.Tracing_pb2 import SegmentObject, SpanObject, Log, SegmentReference
 from skywalking.trace.segment import Segment
 
 logger = logging.getLogger(__name__)

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -18,13 +18,13 @@
 import logging
 
 import grpc
-from common.Common_pb2 import KeyStringValuePair
-from language_agent.Tracing_pb2_grpc import TraceSegmentReportServiceStub
-from management.Management_pb2 import InstancePingPkg, InstanceProperties
-from management.Management_pb2_grpc import ManagementServiceStub
 
 from skywalking import config
 from skywalking.client import ServiceManagementClient, TraceSegmentReportService
+from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
+from skywalking.protocol.language_agent.Tracing_pb2_grpc import TraceSegmentReportServiceStub
+from skywalking.protocol.management.Management_pb2 import InstancePingPkg, InstanceProperties
+from skywalking.protocol.management.Management_pb2_grpc import ManagementServiceStub
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The current version generates codes from proto files into a global namespace, which causes failure when there is a package in the users' application whose name is the same as the generated one, this patch moves the generated codes into the `skywalking` module and thus avoid conflicts.

Resolves https://github.com/apache/skywalking/issues/5406
