### PR TITLE
Mitigate unsafe yaml loading

### DIFF
--- a/tests/plugin/base.py
+++ b/tests/plugin/base.py
@@ -30,7 +30,7 @@ from requests import Response
 try:
     from yaml import CSafeLoader as Loader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeLoader as Loader
 
 
 class TestPluginBase(ABC):

--- a/tests/plugin/base.py
+++ b/tests/plugin/base.py
@@ -28,9 +28,9 @@ import yaml
 from requests import Response
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as Loader
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader
 
 
 class TestPluginBase(ABC):


### PR DESCRIPTION
This is to mitigate security issue `Use of unsafe yaml load` found in https://console.muse.dev/result/ayorra/skywalking-python/01EK1BP85DHDEV2RJTTEYFNV9G?tab=results

According to https://pyyaml.org/wiki/PyYAMLDocumentation
Ideally we should always use safe_load in place of load when the source of yaml can be untrusted (which IS the case because it's from the web)

But I understand that we also want to use CLoader for the sake of performance.
This is a mitigation following https://github.com/yaml/pyyaml/blob/2f463cf5b0e98a52bc20e348d1e69761bf263b86/tests/lib/test_yaml_ext.py#L37