### PR TITLE
The shebang must be on the first line

### DIFF
--- a/tools/env/build_requirements_linux.sh
+++ b/tools/env/build_requirements_linux.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/sh
 
 root_dir=$(dirname "$0")/../../
 

--- a/tools/env/setup_linux.sh
+++ b/tools/env/setup_linux.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#!/bin/sh
 
 root_dir=$(dirname "$0")/../../
 


### PR DESCRIPTION
This is to address a Shellcheck finding from static analysis https://console.muse.dev/result/ayorra/skywalking-python/01EK1BP85DHDEV2RJTTEYFNV9G?tab=results

In shell scripts, the shebang line must be the first or it has no effect at all.

Please refer to https://stackoverflow.com/questions/12910744/why-should-the-shebang-line-always-be-the-first-line