### PR TITLE
Refactor: moved exception check to Span.__exit__

### DIFF
--- a/skywalking/plugins/sw_elasticsearch.py
+++ b/skywalking/plugins/sw_elasticsearch.py
@@ -34,16 +34,12 @@ def install():
         with context.new_exit_span(op="Elasticsearch/" + method + url, peer=peer) as span:
             span.layer = Layer.Database
             span.component = Component.Elasticsearch
-            try:
-                res = _perform_request(this, method, url, headers=headers, params=params, body=body)
+            res = _perform_request(this, method, url, headers=headers, params=params, body=body)
 
-                span.tag(Tag(key=tags.DbType, val="Elasticsearch"))
-                if config.elasticsearch_trace_dsl:
-                    span.tag(Tag(key=tags.DbStatement, val="" if body is None else body))
+            span.tag(Tag(key=tags.DbType, val="Elasticsearch"))
+            if config.elasticsearch_trace_dsl:
+                span.tag(Tag(key=tags.DbStatement, val="" if body is None else body))
 
-            except BaseException as e:
-                span.raised()
-                raise e
             return res
 
     Transport.perform_request = _sw_perform_request

--- a/skywalking/plugins/sw_kafka.py
+++ b/skywalking/plugins/sw_kafka.py
@@ -88,14 +88,11 @@ def _sw_send_func(_send):
                 for item in carrier:
                     headers.append((item.key, item.val.encode("utf-8")))
 
-            try:
-                res = _send(this, topic, value=value, key=key, headers=headers, partition=partition,
-                            timestamp_ms=timestamp_ms)
-                span.tag(Tag(key=tags.MqBroker, val=peer))
-                span.tag(Tag(key=tags.MqTopic, val=topic))
-            except BaseException as e:
-                span.raised()
-                raise e
+            res = _send(this, topic, value=value, key=key, headers=headers, partition=partition,
+                        timestamp_ms=timestamp_ms)
+            span.tag(Tag(key=tags.MqBroker, val=peer))
+            span.tag(Tag(key=tags.MqTopic, val=topic))
+
             return res
 
     return _sw_send

--- a/skywalking/plugins/sw_pymongo.py
+++ b/skywalking/plugins/sw_pymongo.py
@@ -65,23 +65,19 @@ def inject_socket_info(SocketInfo):
             operation = list(spec.keys())[0]
             sw_op = operation.capitalize() + "Operation"
             with context.new_exit_span(op="MongoDB/" + sw_op, peer=peer, carrier=carrier) as span:
-                try:
-                    result = _command(this, dbname, spec, *args, **kwargs)
+                result = _command(this, dbname, spec, *args, **kwargs)
 
-                    span.layer = Layer.Database
-                    span.component = Component.MongoDB
-                    span.tag(Tag(key=tags.DbType, val="MongoDB"))
-                    span.tag(Tag(key=tags.DbInstance, val=dbname))
+                span.layer = Layer.Database
+                span.component = Component.MongoDB
+                span.tag(Tag(key=tags.DbType, val="MongoDB"))
+                span.tag(Tag(key=tags.DbInstance, val=dbname))
 
-                    if config.pymongo_trace_parameters:
-                        # get filters
-                        filters = _get_filter(operation, spec)
-                        max_len = config.pymongo_parameters_max_length
-                        filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                        span.tag(Tag(key=tags.DbStatement, val=filters))
-                except BaseException as e:
-                    span.raised()
-                    raise e
+                if config.pymongo_trace_parameters:
+                    # get filters
+                    filters = _get_filter(operation, spec)
+                    max_len = config.pymongo_parameters_max_length
+                    filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
+                    span.tag(Tag(key=tags.DbStatement, val=filters))
 
         else:
             result = _command(this, dbname, spec, *args, **kwargs)
@@ -123,26 +119,21 @@ def inject_bulk_write(_Bulk, bulk_op_map):
             span.layer = Layer.Database
             span.component = Component.MongoDB
 
-            try:
-                bulk_result = _execute(this, *args, **kwargs)
+            bulk_result = _execute(this, *args, **kwargs)
 
-                span.tag(Tag(key=tags.DbType, val="MongoDB"))
-                span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
-                if config.pymongo_trace_parameters:
-                    filters = ""
-                    bulk_ops = this.ops
-                    for bulk_op in bulk_ops:
-                        opname = bulk_op_map.get(bulk_op[0])
-                        _filter = opname + " " + str(bulk_op[1])
-                        filters = filters + _filter + " "
+            span.tag(Tag(key=tags.DbType, val="MongoDB"))
+            span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
+            if config.pymongo_trace_parameters:
+                filters = ""
+                bulk_ops = this.ops
+                for bulk_op in bulk_ops:
+                    opname = bulk_op_map.get(bulk_op[0])
+                    _filter = opname + " " + str(bulk_op[1])
+                    filters = filters + _filter + " "
 
-                    max_len = config.pymongo_parameters_max_length
-                    filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                    span.tag(Tag(key=tags.DbStatement, val=filters))
-
-            except BaseException as e:
-                span.raised()
-                raise e
+                max_len = config.pymongo_parameters_max_length
+                filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
+                span.tag(Tag(key=tags.DbStatement, val=filters))
 
             return bulk_result
 
@@ -164,22 +155,17 @@ def inject_cursor(Cursor):
             span.layer = Layer.Database
             span.component = Component.MongoDB
 
-            try:
-                # __send_message return nothing
-                __send_message(this, operation)
+            # __send_message return nothing
+            __send_message(this, operation)
 
-                span.tag(Tag(key=tags.DbType, val="MongoDB"))
-                span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
+            span.tag(Tag(key=tags.DbType, val="MongoDB"))
+            span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
 
-                if config.pymongo_trace_parameters:
-                    filters = "find " + str(operation.spec)
-                    max_len = config.pymongo_parameters_max_length
-                    filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                    span.tag(Tag(key=tags.DbStatement, val=filters))
-
-            except BaseException as e:
-                span.raised()
-                raise e
+            if config.pymongo_trace_parameters:
+                filters = "find " + str(operation.spec)
+                max_len = config.pymongo_parameters_max_length
+                filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
+                span.tag(Tag(key=tags.DbStatement, val=filters))
 
             return
 

--- a/skywalking/plugins/sw_pymysql.py
+++ b/skywalking/plugins/sw_pymysql.py
@@ -37,22 +37,18 @@ def install():
         with context.new_exit_span(op="Mysql/PyMsql/execute", peer=peer, carrier=carrier) as span:
             span.layer = Layer.Database
             span.component = Component.PyMysql
-            try:
-                res = _execute(this, query, args)
+            res = _execute(this, query, args)
 
-                span.tag(Tag(key=tags.DbType, val="mysql"))
-                span.tag(Tag(key=tags.DbInstance, val=this.connection.db.decode("utf-8")))
-                span.tag(Tag(key=tags.DbStatement, val=query))
+            span.tag(Tag(key=tags.DbType, val="mysql"))
+            span.tag(Tag(key=tags.DbInstance, val=this.connection.db.decode("utf-8")))
+            span.tag(Tag(key=tags.DbStatement, val=query))
 
-                if config.mysql_trace_sql_parameters and args:
-                    parameter = ",".join([str(arg) for arg in args])
-                    max_len = config.mysql_sql_parameters_max_length
-                    parameter = parameter[0:max_len] + "..." if len(parameter) > max_len else parameter
-                    span.tag(Tag(key=tags.DbSqlParameters, val='[' + parameter + ']'))
+            if config.mysql_trace_sql_parameters and args:
+                parameter = ",".join([str(arg) for arg in args])
+                max_len = config.mysql_sql_parameters_max_length
+                parameter = parameter[0:max_len] + "..." if len(parameter) > max_len else parameter
+                span.tag(Tag(key=tags.DbSqlParameters, val='[' + parameter + ']'))
 
-            except BaseException as e:
-                span.raised()
-                raise e
             return res
 
     Cursor.execute = _sw_execute

--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -59,18 +59,15 @@ def _sw_basic_publish_func(_basic_publish):
                 for item in carrier:
                     properties.headers[item.key] = item.val
 
-            try:
-                res = _basic_publish(this, exchange,
-                                     routing_key,
-                                     body,
-                                     properties=properties,
-                                     mandatory=mandatory)
-                span.tag(Tag(key=tags.MqBroker, val=peer))
-                span.tag(Tag(key=tags.MqTopic, val=exchange))
-                span.tag(Tag(key=tags.MqQueue, val=routing_key))
-            except BaseException as e:
-                span.raised()
-                raise e
+            res = _basic_publish(this, exchange,
+                                 routing_key,
+                                 body,
+                                 properties=properties,
+                                 mandatory=mandatory)
+            span.tag(Tag(key=tags.MqBroker, val=peer))
+            span.tag(Tag(key=tags.MqTopic, val=exchange))
+            span.tag(Tag(key=tags.MqQueue, val=routing_key))
+
             return res
 
     return _sw_basic_publish
@@ -91,13 +88,9 @@ def _sw__on_deliver_func(__on_deliver):
                                        + "/Consumer" or "", carrier=carrier) as span:
             span.layer = Layer.MQ
             span.component = Component.RabbitmqConsumer
-            try:
-                __on_deliver(this, method_frame, header_frame, body)
-                span.tag(Tag(key=tags.MqBroker, val=peer))
-                span.tag(Tag(key=tags.MqTopic, val=exchange))
-                span.tag(Tag(key=tags.MqQueue, val=routing_key))
-            except BaseException as e:
-                span.raised()
-                raise e
+            __on_deliver(this, method_frame, header_frame, body)
+            span.tag(Tag(key=tags.MqBroker, val=peer))
+            span.tag(Tag(key=tags.MqTopic, val=exchange))
+            span.tag(Tag(key=tags.MqQueue, val=routing_key))
 
     return _sw__on_deliver

--- a/skywalking/plugins/sw_redis.py
+++ b/skywalking/plugins/sw_redis.py
@@ -37,14 +37,11 @@ def install():
             span.layer = Layer.Cache
             span.component = Component.Redis
 
-            try:
-                res = _send_command(this, *args, **kwargs)
-                span.tag(Tag(key=tags.DbType, val="Redis"))
-                span.tag(Tag(key=tags.DbInstance, val=this.db))
-                span.tag(Tag(key=tags.DbStatement, val=op))
-            except BaseException as e:
-                span.raised()
-                raise e
+            res = _send_command(this, *args, **kwargs)
+            span.tag(Tag(key=tags.DbType, val="Redis"))
+            span.tag(Tag(key=tags.DbInstance, val=this.db))
+            span.tag(Tag(key=tags.DbStatement, val=op))
+
             return res
 
     Connection.send_command = _sw_send_command

--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -60,20 +60,17 @@ def install():
                 for item in carrier:
                     headers[item.key] = item.val
 
-            try:
-                res = _request(this, method, url, params, data, headers, cookies, files, auth, timeout,
-                               allow_redirects,
-                               proxies,
-                               hooks, stream, verify, cert, json)
+            res = _request(this, method, url, params, data, headers, cookies, files, auth, timeout,
+                           allow_redirects,
+                           proxies,
+                           hooks, stream, verify, cert, json)
 
-                span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
-                span.tag(Tag(key=tags.HttpUrl, val=url))
-                span.tag(Tag(key=tags.HttpStatus, val=res.status_code))
-                if res.status_code >= 400:
-                    span.error_occurred = True
-            except BaseException as e:
-                span.raised()
-                raise e
+            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
+            span.tag(Tag(key=tags.HttpUrl, val=url))
+            span.tag(Tag(key=tags.HttpStatus, val=res.status_code))
+            if res.status_code >= 400:
+                span.error_occurred = True
+
             return res
 
     Session.request = _sw_request

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -49,17 +49,14 @@ def install():
                 for item in carrier:
                     headers[item.key] = item.val
 
-            try:
-                res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
+            res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
 
-                span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
-                span.tag(Tag(key=tags.HttpUrl, val=url))
-                span.tag(Tag(key=tags.HttpStatus, val=res.status))
-                if res.status >= 400:
-                    span.error_occurred = True
-            except BaseException as e:
-                span.raised()
-                raise e
+            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
+            span.tag(Tag(key=tags.HttpUrl, val=url))
+            span.tag(Tag(key=tags.HttpStatus, val=res.status))
+            if res.status >= 400:
+                span.error_occurred = True
+
             return res
 
     RequestMethods.request = _sw_request

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 def install():
     from urllib.request import OpenerDirector
-    from urllib.error import HTTPError
 
     _open = OpenerDirector.open
 
@@ -45,16 +44,13 @@ def install():
 
             [fullurl.add_header(item.key, item.val) for item in carrier]
 
-            try:
-                res = _open(this, fullurl, data, timeout)
-                span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
-                span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
-                span.tag(Tag(key=tags.HttpStatus, val=res.code))
-                if res.code >= 400:
-                    span.error_occurred = True
-            except HTTPError as e:
-                span.raised()
-                raise e
+            res = _open(this, fullurl, data, timeout)
+            span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
+            span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
+            span.tag(Tag(key=tags.HttpStatus, val=res.code))
+            if res.code >= 400:
+                span.error_occurred = True
+
             return res
 
     OpenerDirector.open = _sw_open

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -117,6 +117,8 @@ class Span(ABC):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if isinstance(exc_type, BaseException):
+            self.raised()
         self.stop()
         if exc_tb is not None:
             return False


### PR DESCRIPTION
Moved exception check for spans into Span.__exit__ from multiple individual locations in individual plugins. This should also catch other errors that may not be recognized otherwise. Is there any reason not to do it like this?

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
