### PR TITLE
[Plugin] moved Method & Url tags before requests

### DIFF
--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -60,13 +60,14 @@ def install():
                 for item in carrier:
                     headers[item.key] = item.val
 
+            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
+            span.tag(Tag(key=tags.HttpUrl, val=url))
+
             res = _request(this, method, url, params, data, headers, cookies, files, auth, timeout,
                            allow_redirects,
                            proxies,
                            hooks, stream, verify, cert, json)
 
-            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
-            span.tag(Tag(key=tags.HttpUrl, val=url))
             span.tag(Tag(key=tags.HttpStatus, val=res.status_code))
             if res.status_code >= 400:
                 span.error_occurred = True

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -49,10 +49,11 @@ def install():
                 for item in carrier:
                     headers[item.key] = item.val
 
-            res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
-
             span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
             span.tag(Tag(key=tags.HttpUrl, val=url))
+
+            res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
+
             span.tag(Tag(key=tags.HttpStatus, val=res.status))
             if res.status >= 400:
                 span.error_occurred = True

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -46,14 +46,14 @@ def install():
 
             [fullurl.add_header(item.key, item.val) for item in carrier]
 
-            span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
-            span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
-
             try:
                 res = _open(this, fullurl, data, timeout)
             except HTTPError as e:
                 span.tag(Tag(key=tags.HttpStatus, val=e.code))
                 raise
+            finally:  # we do this here because it may change in _open()
+                span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
+                span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
 
             span.tag(Tag(key=tags.HttpStatus, val=res.code))
             if res.code >= 400:


### PR DESCRIPTION
* Moved set of HttpMethod and HttpUrl tags to before requests to make sure they are recorded even if request fails.
* Specifically catching HTTPError in `sw_urllib_request.py` to properly set HttpStatus in this case.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
