### PR TITLE
[Plugin] http servers set URL and status tags

### DIFF
--- a/skywalking/plugins/sw_django.py
+++ b/skywalking/plugins/sw_django.py
@@ -66,7 +66,7 @@ def install():
                              val=params_tostring(request.GET)[0:config.http_params_length_threshold]))
 
             resp = _get_response(this, request)
-            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code))
+            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code, overridable=True))
             if resp.status_code >= 400:
                 span.error_occurred = True
             return resp

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -58,7 +58,7 @@ def install():
             if resp.status_code >= 400:
                 span.error_occurred = True
 
-            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code))
+            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code, overridable=True))
             return resp
 
     def _sw_handle_user_exception(this: Flask, e):

--- a/skywalking/plugins/sw_http_server.py
+++ b/skywalking/plugins/sw_http_server.py
@@ -75,7 +75,7 @@ def wrap_werkzeug_request_handler(handler):
             finally:
                 status_code = int(getattr(handler, '_status_code', -1))
                 if status_code > -1:
-                    span.tag(Tag(key=tags.HttpStatus, val=status_code))
+                    span.tag(Tag(key=tags.HttpStatus, val=status_code, overridable=True))
                     if status_code >= 400:
                         span.error_occurred = True
 
@@ -123,7 +123,7 @@ def _wrap_do_method(handler, method):
                 finally:
                     status_code = int(getattr(handler, '_status_code', -1))
                     if status_code > -1:
-                        span.tag(Tag(key=tags.HttpStatus, val=status_code))
+                        span.tag(Tag(key=tags.HttpStatus, val=status_code, overridable=True))
                         if status_code >= 400:
                             span.error_occurred = True
 

--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -68,7 +68,7 @@ def install():
                            proxies,
                            hooks, stream, verify, cert, json)
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.status_code))
+            span.tag(Tag(key=tags.HttpStatus, val=res.status_code, overridable=True))
             if res.status_code >= 400:
                 span.error_occurred = True
 

--- a/skywalking/plugins/sw_tornado.py
+++ b/skywalking/plugins/sw_tornado.py
@@ -66,7 +66,7 @@ def _gen_sw_get_response_func(old_execute):
                 span.tag(
                     Tag(key=tags.HttpUrl, val='{}://{}{}'.format(request.protocol, request.host, request.path)))
                 result = old_execute(self, *args, **kwargs)
-                span.tag(Tag(key=tags.HttpStatus, val=self._status_code))
+                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
                 if isawaitable(result):
                     result = await result
                 if self._status_code >= 400:
@@ -90,7 +90,7 @@ def _gen_sw_get_response_func(old_execute):
                 span.tag(
                     Tag(key=tags.HttpUrl, val='{}://{}{}'.format(request.protocol, request.host, request.path)))
                 result = yield from old_execute(self, *args, **kwargs)
-                span.tag(Tag(key=tags.HttpStatus, val=self._status_code))
+                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
                 if self._status_code >= 400:
                     span.error_occurred = True
             return result

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -54,7 +54,7 @@ def install():
 
             res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.status))
+            span.tag(Tag(key=tags.HttpStatus, val=res.status, overridable=True))
             if res.status >= 400:
                 span.error_occurred = True
 

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -49,13 +49,13 @@ def install():
             try:
                 res = _open(this, fullurl, data, timeout)
             except HTTPError as e:
-                span.tag(Tag(key=tags.HttpStatus, val=e.code))
+                span.tag(Tag(key=tags.HttpStatus, val=e.code, overridable=True))
                 raise
             finally:  # we do this here because it may change in _open()
                 span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
                 span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.code))
+            span.tag(Tag(key=tags.HttpStatus, val=res.code, overridable=True))
             if res.code >= 400:
                 span.error_occurred = True
 

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -28,12 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 def install():
+    import socket
     from urllib.request import OpenerDirector
     from urllib.error import HTTPError
 
     _open = OpenerDirector.open
 
-    def _sw_open(this: OpenerDirector, fullurl, data, timeout):
+    def _sw_open(this: OpenerDirector, fullurl, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
         if isinstance(fullurl, str):
             fullurl = Request(fullurl, data)
 
@@ -43,21 +44,25 @@ def install():
         with context.new_exit_span(op=url, peer=fullurl.host, carrier=carrier) as span:
             span.layer = Layer.Http
             span.component = Component.General
+            code = None
 
             [fullurl.add_header(item.key, item.val) for item in carrier]
 
             try:
                 res = _open(this, fullurl, data, timeout)
+                code = res.code
             except HTTPError as e:
-                span.tag(Tag(key=tags.HttpStatus, val=e.code, overridable=True))
+                code = e.code
                 raise
             finally:  # we do this here because it may change in _open()
                 span.tag(Tag(key=tags.HttpMethod, val=fullurl.get_method()))
                 span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.code, overridable=True))
-            if res.code >= 400:
-                span.error_occurred = True
+                if code is not None:
+                    span.tag(Tag(key=tags.HttpStatus, val=code, overridable=True))
+
+                    if code >= 400:
+                        span.error_occurred = True
 
             return res
 

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -116,7 +116,7 @@ class Span(ABC):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(exc_type, BaseException):
+        if isinstance(exc_val, BaseException):
             self.raised()
         self.stop()
         if exc_tb is not None:

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -87,14 +87,13 @@ class Span(ABC):
         return self
 
     def tag(self, tag: Tag) -> 'Span':
-        if not tag.overridable:
-            self.tags.append(deepcopy(tag))
-            return self
+        if tag.overridable:
+            for i, t in enumerate(self.tags):
+                if t.key == tag.key:
+                    self.tags[i] = deepcopy(tag)
+                    return self
 
-        for t in self.tags:
-            if t.key == tag.key:
-                t.val = tag.val
-                break
+        self.tags.append(deepcopy(tag))
 
         return self
 

--- a/tests/plugin/sw_http/expected.data.yml
+++ b/tests/plugin/sw_http/expected.data.yml
@@ -29,6 +29,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://provider:9091/users
+              - key: status.code
+                value: '200'
             refs:
               - parentEndpoint: /users
                 networkAddress: provider:9091
@@ -75,6 +79,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://0.0.0.0:9090/
+              - key: status.code
+                value: '200'
             startTime: gt 0
             endTime: gt 0
             componentId: 7000

--- a/tests/plugin/sw_http_wsgi/expected.data.yml
+++ b/tests/plugin/sw_http_wsgi/expected.data.yml
@@ -29,6 +29,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://provider:9091/users
+              - key: status.code
+                value: '200'
             refs:
               - parentEndpoint: /users
                 networkAddress: provider:9091
@@ -75,6 +79,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://0.0.0.0:9090/
+              - key: status.code
+                value: '200'
             startTime: gt 0
             endTime: gt 0
             componentId: 7000

--- a/tests/plugin/sw_requests/expected.data.yml
+++ b/tests/plugin/sw_requests/expected.data.yml
@@ -29,6 +29,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://provider:9091/users
+              - key: status.code
+                value: '200'
             refs:
               - parentEndpoint: /users
                 networkAddress: provider:9091
@@ -75,6 +79,10 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
+              - key: url
+                value: http://0.0.0.0:9090/
+              - key: status.code
+                value: '200'
             startTime: gt 0
             endTime: gt 0
             componentId: 7000


### PR DESCRIPTION
* Base HTTP and werkzeug servers instrumented to store status code when that is sent and set it as tag for active span, as well as URL from headers.
* Fixed Span.tag() - Previously would try to change an immutable property when overriding, now replaces entire Tag.
* Fixed sw_urllib_request.py:sw_open() - Added default values to parameters because without them it would fail when called internally in urllib.request without a `data` argument, like in `HTTPRedirectHandler.http_error_302()`.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
