### PR TITLE
Fix: Non-global skywalking logging

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import logging
+from skywalking.loggings import logger
 from queue import Queue
 from threading import Thread, Event
 from typing import TYPE_CHECKING
@@ -25,8 +25,6 @@ from skywalking.agent.protocol import Protocol
 
 if TYPE_CHECKING:
     from skywalking.trace.context import Segment
-
-logger = logging.getLogger(__name__)
 
 
 def __heartbeat():

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import logging
+from skywalking.loggings import logger
 import traceback
 from queue import Queue
 
@@ -28,8 +28,6 @@ from skywalking.client.grpc import GrpcServiceManagementClient, GrpcTraceSegment
 from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.language_agent.Tracing_pb2 import SegmentObject, SpanObject, Log, SegmentReference
 from skywalking.trace.segment import Segment
-
-logger = logging.getLogger(__name__)
 
 
 class GrpcProtocol(Protocol):

--- a/skywalking/agent/protocol/http.py
+++ b/skywalking/agent/protocol/http.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 #
 
-import logging
+from skywalking.loggings import logger
 from queue import Queue
 
 from skywalking.agent import Protocol
 from skywalking.client.http import HttpServiceManagementClient, HttpTraceSegmentReportService
 from skywalking.trace.segment import Segment
-
-logger = logging.getLogger(__name__)
 
 
 class HttpProtocol(Protocol):

--- a/skywalking/agent/protocol/kafka.py
+++ b/skywalking/agent/protocol/kafka.py
@@ -16,6 +16,7 @@
 #
 
 import logging
+from skywalking.loggings import logger, getLogger
 from queue import Queue
 
 from skywalking import config
@@ -25,11 +26,9 @@ from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.language_agent.Tracing_pb2 import SegmentObject, SpanObject, Log, SegmentReference
 from skywalking.trace.segment import Segment
 
-logger = logging.getLogger(__name__)
-
 # avoid too many kafka logs
-logger_kafka = logging.getLogger('kafka')
-logger_kafka.setLevel(logging.WARN)
+logger_kafka = getLogger('kafka')
+logger_kafka.setLevel(max(logging.WARN, logger.level))
 
 
 class KafkaProtocol(Protocol):

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import logging
+from skywalking.loggings import logger
 
 import grpc
 
@@ -25,8 +25,6 @@ from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.language_agent.Tracing_pb2_grpc import TraceSegmentReportServiceStub
 from skywalking.protocol.management.Management_pb2 import InstancePingPkg, InstanceProperties
 from skywalking.protocol.management.Management_pb2_grpc import ManagementServiceStub
-
-logger = logging.getLogger(__name__)
 
 
 class GrpcServiceManagementClient(ServiceManagementClient):

--- a/skywalking/client/http.py
+++ b/skywalking/client/http.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 #
 
-import logging
+from skywalking.loggings import logger
 
 import requests
 
 from skywalking import config
 from skywalking.client import ServiceManagementClient, TraceSegmentReportService
-
-logger = logging.getLogger(__name__)
 
 
 class HttpServiceManagementClient(ServiceManagementClient):

--- a/skywalking/client/kafka.py
+++ b/skywalking/client/kafka.py
@@ -17,7 +17,7 @@
 
 import os
 import ast
-import logging
+from skywalking.loggings import logger
 
 from skywalking import config
 from skywalking.client import ServiceManagementClient, TraceSegmentReportService
@@ -25,8 +25,6 @@ from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.management.Management_pb2 import InstancePingPkg, InstanceProperties
 
 from kafka import KafkaProducer
-
-logger = logging.getLogger(__name__)
 
 kafka_configs = {}
 

--- a/skywalking/loggings.py
+++ b/skywalking/loggings.py
@@ -34,5 +34,5 @@ logger = getLogger('skywalking')
 
 
 def init():
-    logging.addLevelName(logging.getLevelName('CRITICAL') + 10, 'OFF')
+    logging.addLevelName(logging.CRITICAL + 10, 'OFF')
     logger.setLevel(logging.getLevelName(config.logging_level))

--- a/skywalking/loggings.py
+++ b/skywalking/loggings.py
@@ -20,8 +20,19 @@ import logging
 from skywalking import config
 
 
+def getLogger(name=None):
+    logger = logging.getLogger(name)
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter('%(name)-32s [%(threadName)-15s] [%(levelname)-8s] %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    return logger
+
+
+logger = getLogger('skywalking')
+
+
 def init():
-    logging.basicConfig(
-        level=logging.getLevelName(config.logging_level),
-        format='%(name)-32s [%(threadName)-15s] [%(levelname)-8s] %(message)s',
-    )
+    logging.addLevelName(logging.getLevelName('CRITICAL') + 10, 'OFF')
+    logger.setLevel(logging.getLevelName(config.logging_level))

--- a/skywalking/plugins/__init__.py
+++ b/skywalking/plugins/__init__.py
@@ -16,6 +16,7 @@
 #
 import inspect
 import logging
+from skywalking.loggings import logger
 import pkgutil
 import re
 import traceback
@@ -27,8 +28,6 @@ from packaging import version
 from skywalking import config
 
 import skywalking
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_django.py
+++ b/skywalking/plugins/sw_django.py
@@ -14,15 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component, config
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 version_rule = {
     "name": "django",

--- a/skywalking/plugins/sw_elasticsearch.py
+++ b/skywalking/plugins/sw_elasticsearch.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component, config
 from skywalking.trace import tags
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component, config
 from skywalking.trace import tags
@@ -22,8 +21,6 @@ from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.span import NoopSpan
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_http_server.py
+++ b/skywalking/plugins/sw_http_server.py
@@ -14,16 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import inspect
-import logging
 
 from skywalking import Layer, Component
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_kafka.py
+++ b/skywalking/plugins/sw_kafka.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import config
 from skywalking import Layer, Component
@@ -22,8 +21,6 @@ from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_pymongo.py
+++ b/skywalking/plugins/sw_pymongo.py
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-import logging
-
 from skywalking import Layer, Component, config
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 version_rule = {
     "name": "pymongo",

--- a/skywalking/plugins/sw_pymysql.py
+++ b/skywalking/plugins/sw_pymysql.py
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
+
 from skywalking import Layer, Component, config
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -14,15 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_redis.py
+++ b/skywalking/plugins/sw_redis.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component
 from skywalking.trace import tags
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
 from skywalking import Layer, Component
 from skywalking.trace import tags
@@ -22,8 +21,6 @@ from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
 from skywalking import config
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_tornado.py
+++ b/skywalking/plugins/sw_tornado.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
+
 from inspect import iscoroutinefunction, isawaitable
 
 from skywalking import Layer, Component
@@ -22,8 +22,6 @@ from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -15,15 +15,11 @@
 # limitations under the License.
 #
 
-import logging
-
 from skywalking import Layer, Component
 from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import logging
 from urllib.request import Request
 
 from skywalking import Layer, Component
@@ -23,8 +22,6 @@ from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import Tag
-
-logger = logging.getLogger(__name__)
 
 
 def install():

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import logging
 import threading
 from typing import List
 
@@ -27,8 +26,6 @@ from skywalking.trace.snapshot import Snapshot
 from skywalking.trace.span import Span, Kind, NoopSpan, EntrySpan, ExitSpan
 from skywalking.utils.ant_matcher import fast_path_match
 from skywalking.utils.counter import Counter
-
-logger = logging.getLogger(__name__)
 
 
 class SpanContext(object):


### PR DESCRIPTION
* Changed logging to use a single skywalking Logger instance instead of global Logger and settings to avoid changing or breaking  host application logging with skywalking logger settings.
* Also added custom logging level "OFF".

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
