### PR TITLE
test: make tests really run on specified Py version and deprecate 3.5 as it's EOL

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,3 +29,12 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  protected_branches:
+    master:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CheckStatus
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
       fail-fast: false
+    env:
+      SW_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - name: Checkout source codes
         uses: actions/checkout@v2
@@ -40,10 +42,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up dependencies
+        if: ${{ matrix.python-version != '3.5' }}
         run: make setup install
       - name: Lint codes
+        if: ${{ matrix.python-version != '3.5' }}
         run: make lint
       - name: Check license header
+        if: ${{ matrix.python-version != '3.5' }}
         run: make license
       - name: Run unit tests
+        if: ${{ matrix.python-version != '3.5' }}
         run: make test
+
+  CheckStatus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: [Build]
+    steps:
+      - name: Nothing
+        run: echo "Just to make the GitHub merge button green"

--- a/tests/plugin/docker/Dockerfile.agent
+++ b/tests/plugin/docker/Dockerfile.agent
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7
+ARG SW_PYTHON_VERSION
+
+FROM python:${SW_PYTHON_VERSION}
 
 ARG ROOT=.
 

--- a/tests/plugin/docker/docker-compose.base.yml
+++ b/tests/plugin/docker/docker-compose.base.yml
@@ -37,6 +37,8 @@ services:
     build:
       context: ../../../
       dockerfile: tests/plugin/docker/Dockerfile.agent
+      args:
+        - SW_PYTHON_VERSION=${SW_PYTHON_VERSION:-latest}
     environment:
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
       SW_AGENT_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
[Python 3.5 EOL](https://www.python.org/downloads/release/python-3510/)

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
