### PR TITLE
[Bugfix] allow pending data to send before exit

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -15,12 +15,13 @@
 # limitations under the License.
 #
 
-from skywalking.loggings import logger
+import atexit
 from queue import Queue
 from threading import Thread, Event
 from typing import TYPE_CHECKING
 
-from skywalking import config, plugins
+from skywalking import config, plugins, loggings
+from skywalking.loggings import logger
 from skywalking.agent.protocol import Protocol
 
 if TYPE_CHECKING:
@@ -38,7 +39,8 @@ def __heartbeat():
 def __report():
     while not __finished.is_set():
         if connected():
-            __protocol.report(__queue)  # is blocking actually
+            while __protocol.report(__queue):  # blocking but has timeout
+                pass
 
         __finished.wait(1)
 
@@ -70,16 +72,18 @@ def start():
     global __started
     if __started:
         raise RuntimeError('the agent can only be started once')
-    from skywalking import loggings
     loggings.init()
     config.finalize()
     __started = True
     __init()
     __heartbeat_thread.start()
     __report_thread.start()
+    atexit.register(__protocol.report, (__queue, False))
 
 
 def stop():
+    atexit.unregister(__protocol.report)
+    __protocol.report(__queue, False)
     __finished.set()
 
 

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -39,8 +39,7 @@ def __heartbeat():
 def __report():
     while not __finished.is_set():
         if connected():
-            while __protocol.report(__queue):  # blocking but has timeout
-                pass
+            __protocol.report(__queue)  # is blocking actually
 
         __finished.wait(1)
 

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -68,6 +68,11 @@ def __init():
     plugins.install()
 
 
+def __fini():
+    __protocol.report(__queue, False)
+    __queue.join()
+
+
 def start():
     global __started
     if __started:
@@ -78,12 +83,12 @@ def start():
     __init()
     __heartbeat_thread.start()
     __report_thread.start()
-    atexit.register(__protocol.report, (__queue, False))
+    atexit.register(__fini)
 
 
 def stop():
-    atexit.unregister(__protocol.report)
-    __protocol.report(__queue, False)
+    atexit.unregister(__fini)
+    __fini()
     __finished.set()
 
 

--- a/skywalking/agent/protocol/__init__.py
+++ b/skywalking/agent/protocol/__init__.py
@@ -26,5 +26,5 @@ class Protocol(ABC):
     def heartbeat(self):
         raise NotImplementedError()
 
-    def report(self, queue: Queue):
+    def report(self, queue: Queue, block: bool = True):
         raise NotImplementedError()

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -18,7 +18,7 @@
 import logging
 from skywalking.loggings import logger
 import traceback
-from queue import Queue, Empty
+from queue import Queue
 
 import grpc
 
@@ -70,10 +70,7 @@ class GrpcProtocol(Protocol):
     def report(self, queue: Queue, block: bool = True):
         def generator():
             while True:
-                try:
-                    segment = queue.get(block=block, timeout=0.5)  # type: Segment
-                except Empty:
-                    break
+                segment = queue.get(block=block)  # type: Segment
 
                 logger.debug('reporting segment %s', segment)
 

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -117,8 +117,5 @@ class GrpcProtocol(Protocol):
 
         try:
             self.traces_reporter.report(generator())
-
-            return True
-
         except grpc.RpcError:
             self.on_error()

--- a/skywalking/agent/protocol/http.py
+++ b/skywalking/agent/protocol/http.py
@@ -50,5 +50,3 @@ class HttpProtocol(Protocol):
                 queue.task_done()
 
         self.traces_reporter.report(generator=generator())
-
-        return True

--- a/skywalking/agent/protocol/http.py
+++ b/skywalking/agent/protocol/http.py
@@ -16,7 +16,7 @@
 #
 
 from skywalking.loggings import logger
-from queue import Queue, Empty
+from queue import Queue
 
 from skywalking.agent import Protocol
 from skywalking.client.http import HttpServiceManagementClient, HttpTraceSegmentReportService
@@ -41,10 +41,7 @@ class HttpProtocol(Protocol):
     def report(self, queue: Queue, block: bool = True):
         def generator():
             while True:
-                try:
-                    segment = queue.get(block=block, timeout=0.5)  # type: Segment
-                except Empty:
-                    break
+                segment = queue.get(block=block)  # type: Segment
 
                 logger.debug('reporting segment %s', segment)
 

--- a/skywalking/agent/protocol/kafka.py
+++ b/skywalking/agent/protocol/kafka.py
@@ -17,7 +17,7 @@
 
 import logging
 from skywalking.loggings import logger, getLogger
-from queue import Queue, Empty
+from queue import Queue
 
 from skywalking import config
 from skywalking.agent import Protocol
@@ -45,10 +45,7 @@ class KafkaProtocol(Protocol):
     def report(self, queue: Queue, block: bool = True):
         def generator():
             while True:
-                try:
-                    segment = queue.get(block=block, timeout=0.5)  # type: Segment
-                except Empty:
-                    break
+                segment = queue.get(block=block)  # type: Segment
 
                 logger.debug('reporting segment %s', segment)
 

--- a/skywalking/agent/protocol/kafka.py
+++ b/skywalking/agent/protocol/kafka.py
@@ -91,5 +91,3 @@ class KafkaProtocol(Protocol):
                 queue.task_done()
 
         self.traces_reporter.report(generator())
-
-        return True


### PR DESCRIPTION
Fixed the problem of last pending data not being sent on exit.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
