### PR TITLE
Fix: BaseExceptions not recorded as errors

### DIFF
--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -116,7 +116,7 @@ class Span(ABC):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(exc_val, BaseException):
+        if isinstance(exc_val, Exception):
             self.raised()
         self.stop()
         if exc_tb is not None:


### PR DESCRIPTION
Minor change to exception checking on span exit, changed check from `BaseException` to `Exception` so that `KeyboardInterrupt`, `SystemExit` or `GeneratorExit` (even though this should never come back here) are not flagged as errors.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
