### PR TITLE
Make Muse ignore bugs types that were false positives.

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,1 @@
+ignore = [ "Unused ignore", "Invalid decoration", "blacklist", "Missing argument" ]


### PR DESCRIPTION
In prior PRs, such as #100 and #102, we received Muse comments about Pyre bugs that are false positives.  While improving Pyre is the right technical solution we can also take the quick path of ignoring the less reliable or useful messages.  By request of @kezhenxu94 I've made this muse configuration that ignores the rules that caused false positive.

@kezhenxu94 sorry it took me longer to get back to this than planned.  Just shout if there are more desired changed.