### PR TITLE
chore: switch http to https of submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "protocol"]
 	path = protocol
-	url = http://github.com/apache/skywalking-data-collect-protocol
+	url = https://github.com/apache/skywalking-data-collect-protocol


### PR DESCRIPTION
`fatal: unable to access 'http://github.com/apache/skywalking-data-collect-protocol/': gnutls_handshake() failed: The TLS connection was non-properly terminated.
` for some env

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
