### PR TITLE
fix: sw_tornado async handler status set correctly

### DIFF
--- a/skywalking/plugins/sw_tornado.py
+++ b/skywalking/plugins/sw_tornado.py
@@ -64,9 +64,9 @@ def _gen_sw_get_response_func(old_execute):
                 span.tag(
                     Tag(key=tags.HttpUrl, val='{}://{}{}'.format(request.protocol, request.host, request.path)))
                 result = old_execute(self, *args, **kwargs)
-                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
                 if isawaitable(result):
                     result = await result
+                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
                 if self._status_code >= 400:
                     span.error_occurred = True
             return result


### PR DESCRIPTION
Don't know how that slipped by undetected for so long...
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
