### PR TITLE
fix module wrapt as normal install dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "grpcio",
         "grpcio-tools",
         "packaging",
+        "wrapt",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Added this to `requirements.txt` in the plugin PR #122 but forgot `setup.py` so test worked due to `requirements.txt` but normal install did not. Also even though this module is only used for `psycog2` currently it will be a necessity for instrumenting any future modules which use C extension objects.

P.S. Do I need to do anything else milestone-wise than just add it to Milestone 0.7.0 here?