### PR TITLE
fix celery origin, detect nonlocal if no sw8 head

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
 
         "Topic :: Software Development",
     ]

--- a/skywalking/plugins/sw_celery.py
+++ b/skywalking/plugins/sw_celery.py
@@ -84,10 +84,11 @@ def install():
                     item.val = val
 
             context = get_context()
+            origin = req.get('origin')
 
-            if req.get('sw8'):
+            if origin:
                 span = context.new_entry_span(op=op, carrier=carrier)
-                span.peer = (req.get('hostname') or '???').split('@', 1)[-1]
+                span.peer = origin.split('@', 1)[-1]
             else:
                 span = context.new_local_span(op=op)
 


### PR DESCRIPTION
Minor fix to set correct type of span (Entry instead of Local) if sw8 header missing due to client not being run under apm. Also setting correct peer instead of server hostname.