### PR TITLE
explicit component inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ with context.new_entry_span(op='https://github.com/apache') as span:
     span.component = Component.Flask
 # the span automatically stops when exiting the `with` context
 
-with context.new_exit_span(op='https://github.com/apache', peer='localhost:8080') as span:
-    span.component = Component.Flask
+with context.new_exit_span(op='https://github.com/apache', peer='localhost:8080', component=Component.Flask) as span:
+    span.tag(Tag(key='Singer', val='Nakajima'))
 
 with context.new_local_span(op='https://github.com/apache') as span:
     span.tag(Tag(key='Singer', val='Nakajima'))

--- a/skywalking/plugins/sw_aiohttp.py
+++ b/skywalking/plugins/sw_aiohttp.py
@@ -33,9 +33,8 @@ def install():
         peer = '%s:%d' % (url.host or '', url.port)
         context = get_context()
 
-        with context.new_exit_span(op=url.path or "/", peer=peer) as span:
+        with context.new_exit_span(op=url.path or "/", peer=peer, component=Component.AioHttp) as span:
             span.layer = Layer.Http
-            span.component = Component.AioHttp
             span.tag(Tag(key=tags.HttpMethod, val=method.upper()))  # pyre-ignore
             span.tag(Tag(key=tags.HttpUrl, val=url))  # pyre-ignore
 

--- a/skywalking/plugins/sw_celery.py
+++ b/skywalking/plugins/sw_celery.py
@@ -42,9 +42,8 @@ def install():
         else:
             peer = '???'
 
-        with get_context().new_exit_span(op=op, peer=peer) as span:
+        with get_context().new_exit_span(op=op, peer=peer, component=Component.Celery) as span:
             span.layer = Layer.MQ
-            span.component = Component.Celery
 
             span.tag(Tag(key=tags.MqBroker, val=broker_url))
             # span.tag(Tag(key=tags.MqTopic, val=exchange))

--- a/skywalking/plugins/sw_elasticsearch.py
+++ b/skywalking/plugins/sw_elasticsearch.py
@@ -28,9 +28,9 @@ def install():
     def _sw_perform_request(this: Transport, method, url, headers=None, params=None, body=None):
         context = get_context()
         peer = ",".join([host["host"] + ":" + str(host["port"]) for host in this.hosts])
-        with context.new_exit_span(op="Elasticsearch/" + method + url, peer=peer) as span:
+        with context.new_exit_span(op="Elasticsearch/" + method + url, peer=peer,
+                                   component=Component.Elasticsearch) as span:
             span.layer = Layer.Database
-            span.component = Component.Elasticsearch
             res = _perform_request(this, method, url, headers=headers, params=params, body=body)
 
             span.tag(Tag(key=tags.DbType, val="Elasticsearch"))

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -41,7 +41,7 @@ def install():
         for item in carrier:
             if item.key.capitalize() in req.headers:
                 item.val = req.headers[item.key.capitalize()]
-        with context.new_entry_span(op=req.path, carrier=carrier) as span:
+        with context.new_entry_span(op=req.path, carrier=carrier, inherit=Component.General) as span:
             span.layer = Layer.Http
             span.component = Component.Flask
             span.peer = '%s:%s' % (req.environ["REMOTE_ADDR"], req.environ["REMOTE_PORT"])

--- a/skywalking/plugins/sw_kafka.py
+++ b/skywalking/plugins/sw_kafka.py
@@ -72,10 +72,10 @@ def _sw_send_func(_send):
 
         peer = ";".join(this.config["bootstrap_servers"])
         context = get_context()
-        with context.new_exit_span(op="Kafka/" + topic + "/Producer" or "/", peer=peer) as span:
+        with context.new_exit_span(op="Kafka/" + topic + "/Producer" or "/", peer=peer,
+                                   component=Component.KafkaProducer) as span:
             carrier = span.inject()
             span.layer = Layer.MQ
-            span.component = Component.KafkaProducer
 
             if headers is None:
                 headers = []

--- a/skywalking/plugins/sw_psycopg2.py
+++ b/skywalking/plugins/sw_psycopg2.py
@@ -38,9 +38,9 @@ def install():
             dsn = self.connection.get_dsn_parameters()
             peer = dsn['host'] + ':' + dsn['port']
 
-            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/execute", peer=peer) as span:
+            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/execute", peer=peer,
+                                             component=Component.Psycopg) as span:
                 span.layer = Layer.Database
-                span.component = Component.Psycopg
 
                 span.tag(Tag(key=tags.DbType, val="PostgreSQL"))
                 span.tag(Tag(key=tags.DbInstance, val=dsn['dbname']))
@@ -60,9 +60,9 @@ def install():
             dsn = self.connection.get_dsn_parameters()
             peer = dsn['host'] + ':' + dsn['port']
 
-            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/executemany", peer=peer) as span:
+            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/executemany", peer=peer,
+                                             component=Component.Psycopg) as span:
                 span.layer = Layer.Database
-                span.component = Component.Psycopg
 
                 span.tag(Tag(key=tags.DbType, val="PostgreSQL"))
                 span.tag(Tag(key=tags.DbInstance, val=dsn['dbname']))
@@ -92,9 +92,9 @@ def install():
             dsn = self.connection.get_dsn_parameters()
             peer = dsn['host'] + ':' + dsn['port']
 
-            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/callproc", peer=peer) as span:
+            with get_context().new_exit_span(op="PostgreSLQ/Psycopg/callproc", peer=peer,
+                                             component=Component.Psycopg) as span:
                 span.layer = Layer.Database
-                span.component = Component.Psycopg
                 args = '(' + ('' if not parameters else ','.join(parameters)) + ')'
 
                 span.tag(Tag(key=tags.DbType, val="PostgreSQL"))

--- a/skywalking/plugins/sw_pymongo.py
+++ b/skywalking/plugins/sw_pymongo.py
@@ -58,11 +58,10 @@ def inject_socket_info(SocketInfo):
 
             operation = list(spec.keys())[0]
             sw_op = operation.capitalize() + "Operation"
-            with context.new_exit_span(op="MongoDB/" + sw_op, peer=peer) as span:
+            with context.new_exit_span(op="MongoDB/" + sw_op, peer=peer, component=Component.MongoDB) as span:
                 result = _command(this, dbname, spec, *args, **kwargs)
 
                 span.layer = Layer.Database
-                span.component = Component.MongoDB
                 span.tag(Tag(key=tags.DbType, val="MongoDB"))
                 span.tag(Tag(key=tags.DbInstance, val=dbname))
 
@@ -108,9 +107,8 @@ def inject_bulk_write(_Bulk, bulk_op_map):
         context = get_context()
 
         sw_op = "MixedBulkWriteOperation"
-        with context.new_exit_span(op="MongoDB/"+sw_op, peer=peer) as span:
+        with context.new_exit_span(op="MongoDB/"+sw_op, peer=peer, component=Component.MongoDB) as span:
             span.layer = Layer.Database
-            span.component = Component.MongoDB
 
             bulk_result = _execute(this, *args, **kwargs)
 
@@ -143,9 +141,8 @@ def inject_cursor(Cursor):
         context = get_context()
         op = "FindOperation"
 
-        with context.new_exit_span(op="MongoDB/"+op, peer=peer) as span:
+        with context.new_exit_span(op="MongoDB/"+op, peer=peer, component=Component.MongoDB) as span:
             span.layer = Layer.Database
-            span.component = Component.MongoDB
 
             # __send_message return nothing
             __send_message(this, operation)

--- a/skywalking/plugins/sw_pymysql.py
+++ b/skywalking/plugins/sw_pymysql.py
@@ -30,9 +30,8 @@ def install():
         peer = "%s:%s" % (this.connection.host, this.connection.port)
 
         context = get_context()
-        with context.new_exit_span(op="Mysql/PyMsql/execute", peer=peer) as span:
+        with context.new_exit_span(op="Mysql/PyMsql/execute", peer=peer, component=Component.PyMysql) as span:
             span.layer = Layer.Database
-            span.component = Component.PyMysql
             res = _execute(this, query, args)
 
             span.tag(Tag(key=tags.DbType, val="mysql"))

--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -41,10 +41,9 @@ def _sw_basic_publish_func(_basic_publish):
         context = get_context()
         import pika
         with context.new_exit_span(op="RabbitMQ/Topic/" + exchange + "/Queue/" + routing_key + "/Producer" or "/",
-                                   peer=peer) as span:
+                                   peer=peer, component=Component.RabbitmqProducer) as span:
             carrier = span.inject()
             span.layer = Layer.MQ
-            span.component = Component.RabbitmqProducer
             properties = pika.BasicProperties() if properties is None else properties
 
             if properties.headers is None:

--- a/skywalking/plugins/sw_redis.py
+++ b/skywalking/plugins/sw_redis.py
@@ -30,9 +30,8 @@ def install():
         peer = "%s:%s" % (this.host, this.port)
         op = args[0]
         context = get_context()
-        with context.new_exit_span(op="Redis/"+op or "/", peer=peer) as span:
+        with context.new_exit_span(op="Redis/"+op or "/", peer=peer, component=Component.Redis) as span:
             span.layer = Layer.Cache
-            span.component = Component.Redis
 
             res = _send_command(this, *args, **kwargs)
             span.tag(Tag(key=tags.DbType, val="Redis"))

--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -43,10 +43,10 @@ def install():
                             hooks, stream, verify, cert, json)
 
         context = get_context()
-        with context.new_exit_span(op=url_param.path or "/", peer=url_param.netloc) as span:
+        with context.new_exit_span(op=url_param.path or "/", peer=url_param.netloc,
+                                   component=Component.Requests) as span:
             carrier = span.inject()
             span.layer = Layer.Http
-            span.component = Component.Requests
 
             if headers is None:
                 headers = {}

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -31,10 +31,10 @@ def install():
         from urllib.parse import urlparse
         url_param = urlparse(url)
         context = get_context()
-        with context.new_exit_span(op=url_param.path or "/", peer=url_param.netloc) as span:
+        with context.new_exit_span(op=url_param.path or "/", peer=url_param.netloc,
+                                   component=Component.Urllib3) as span:
             carrier = span.inject()
             span.layer = Layer.Http
-            span.component = Component.Urllib3
 
             if headers is None:
                 headers = {}

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -36,10 +36,9 @@ def install():
 
         context = get_context()
         url = fullurl.selector.split("?")[0] if fullurl.selector else '/'
-        with context.new_exit_span(op=url, peer=fullurl.host) as span:
+        with context.new_exit_span(op=url, peer=fullurl.host, component=Component.General) as span:
             carrier = span.inject()
             span.layer = Layer.Http
-            span.component = Component.General
             code = None
 
             [fullurl.add_header(item.key, item.val) for item in carrier]

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -55,6 +55,7 @@ class Span(ABC):
         self.kind = kind  # type: Kind
         self.component = component or Component.Unknown  # type: Component
         self.layer = layer or Layer.Unknown  # type: Layer
+        self.inherit = Component.Unknown  # type: Component
 
         self.tags = []  # type: List[Tag]
         self.logs = []  # type: List[Log]


### PR DESCRIPTION
Added explicit component inheritance. This means that plugins must explicitly say they inherit from a specific component in order to be able to inherit and reuse a parent span (like `Component.Flask` inheriting from an http server `Component.General`). If there is no match then a new `Span` is created even if it is the same kind. This is mostly to allow different kinds of exit spans to be created during the processing of some parent exit span which causes certain operations (like db access or message send).

Note: I expect a few errors in the first test runs to show me which components inherit from which others.