### PR TITLE
fix trace decorator

### DIFF
--- a/skywalking/decorators.py
+++ b/skywalking/decorators.py
@@ -32,25 +32,37 @@ def trace(
 ):
     def decorator(func):
         _op = op or func.__name__
-        context = get_context()
-
-        span = context.new_local_span(op=_op)
-        span.layer = layer
-        span.component = component
-        [span.tag(tag) for tag in tags or []]
 
         if inspect.iscoroutinefunction(func):
             @wraps(func)
             async def wrapper(*args, **kwargs):
+                span = get_context().new_local_span(op=_op)
+                span.layer = layer
+                span.component = component
+
+                if tags:
+                    for tag in tags:
+                        span.tag(tag)
+
                 with span:
                     return await func(*args, **kwargs)
+
             return wrapper
 
         else:
             @wraps(func)
             def wrapper(*args, **kwargs):
+                span = get_context().new_local_span(op=_op)
+                span.layer = layer
+                span.component = component
+
+                if tags:
+                    for tag in tags:
+                        span.tag(tag)
+
                 with span:
                     return func(*args, **kwargs)
+
             return wrapper
 
     return decorator


### PR DESCRIPTION
Fix #136

Span was created in wrong place, at time of decoration instead of function call. Please note the decorator must be called as `@trace(...)` instead of `@trace`.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
