### PR TITLE
fix grpc disconnect, SW_AGENT_MAX_BUFFER_SIZE

### DIFF
--- a/docs/EnvVars.md
+++ b/docs/EnvVars.md
@@ -11,6 +11,7 @@ Environment Variable | Description | Default
 | `SW_AGENT_AUTHENTICATION` | The authentication token to verify that the agent is trusted by the backend OAP, as for how to configure the backend, refer to [the yaml](https://github.com/apache/skywalking/blob/4f0f39ffccdc9b41049903cc540b8904f7c9728e/oap-server/server-bootstrap/src/main/resources/application.yml#L155-L158). | unset |
 | `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `CRITICAL`, `FATAL`, `ERROR`, `WARN`(`WARNING`), `INFO`, `DEBUG` | `INFO` |
 | `SW_AGENT_DISABLE_PLUGINS` | The name patterns in CSV pattern, plugins whose name matches one of the pattern won't be installed | `''` |
+| `SW_AGENT_MAX_BUFFER_SIZE` | The maximum queue backlog size for sending the segment data to backend, segments beyond this are silently dropped | `'1000'` |
 | `SW_SQL_PARAMETERS_LENGTH` | The maximum length of the collected parameter, parameters longer than the specified length will be truncated, length 0 turns off parameter tracing | `0` |
 | `SW_PYMONGO_TRACE_PARAMETERS` | Indicates whether to collect the filters of pymongo | `False` |
 | `SW_PYMONGO_PARAMETERS_MAX_LENGTH` | The maximum length of the collected filters, filters longer than the specified length will be truncated |  `512` |

--- a/skywalking/agent/protocol/__init__.py
+++ b/skywalking/agent/protocol/__init__.py
@@ -29,9 +29,6 @@ class Protocol(ABC):
     def fork_after_in_child(self):
         pass
 
-    def connected(self):
-        return False
-
     def heartbeat(self):
         raise NotImplementedError()
 

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -17,7 +17,7 @@
 
 import logging
 import traceback
-from queue import Queue, Empty, Full
+from queue import Queue, Empty
 from time import time
 
 import grpc
@@ -35,15 +35,13 @@ from skywalking.trace.segment import Segment
 
 class GrpcProtocol(Protocol):
     def __init__(self):
+        self.properties_sent = False
         self.state = None
 
         if config.force_tls:
-            self.channel = grpc.secure_channel(config.collector_address, grpc.ssl_channel_credentials(),
-                                               options=(('grpc.max_connection_age_grace_ms',
-                                                         1000 * config.GRPC_TIMEOUT),))
+            self.channel = grpc.secure_channel(config.collector_address, grpc.ssl_channel_credentials())
         else:
-            self.channel = grpc.insecure_channel(config.collector_address, options=(('grpc.max_connection_age_grace_ms',
-                                                 1000 * config.GRPC_TIMEOUT),))
+            self.channel = grpc.insecure_channel(config.collector_address)
 
         if config.authentication:
             self.channel = grpc.intercept_channel(
@@ -58,11 +56,6 @@ class GrpcProtocol(Protocol):
     def _cb(self, state):
         logger.debug('grpc channel connectivity changed, [%s -> %s]', self.state, state)
         self.state = state
-        if self.connected():
-            try:
-                self.service_management.send_instance_props()
-            except grpc.RpcError:
-                self.on_error()
 
     def query_profile_commands(self):
         logger.debug("query profile commands")
@@ -70,12 +63,14 @@ class GrpcProtocol(Protocol):
 
     def heartbeat(self):
         try:
+            if not self.properties_sent:
+                self.service_management.send_instance_props()
+                self.properties_sent = True
+
             self.service_management.send_heart_beat()
+
         except grpc.RpcError:
             self.on_error()
-
-    def connected(self):
-        return self.state == grpc.ChannelConnectivity.READY
 
     def on_error(self):
         traceback.print_exc() if logger.isEnabledFor(logging.DEBUG) else None
@@ -84,17 +79,18 @@ class GrpcProtocol(Protocol):
 
     def report(self, queue: Queue, block: bool = True):
         start = time()
-        segment = None
 
         def generator():
-            nonlocal segment
-
             while True:
                 try:
-                    timeout = max(0, config.QUEUE_TIMEOUT - int(time() - start))  # type: int
+                    timeout = config.QUEUE_TIMEOUT - int(time() - start)  # type: int
+                    if timeout <= 0:  # this is to make sure we exit eventually instead of being fed continuously
+                        return
                     segment = queue.get(block=block, timeout=timeout)  # type: Segment
                 except Empty:
                     return
+
+                queue.task_done()
 
                 logger.debug('reporting segment %s', segment)
 
@@ -137,16 +133,7 @@ class GrpcProtocol(Protocol):
 
                 yield s
 
-                queue.task_done()
-
         try:
             self.traces_reporter.report(generator())
-
         except grpc.RpcError:
             self.on_error()
-
-            if segment:
-                try:
-                    queue.put(segment, block=False)
-                except Full:
-                    pass

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -60,7 +60,7 @@ class GrpcTraceSegmentReportService(TraceSegmentReportService):
         self.report_stub = TraceSegmentReportServiceStub(channel)
 
     def report(self, generator):
-        self.report_stub.collect(generator, timeout=config.GRPC_TIMEOUT)
+        self.report_stub.collect(generator)
 
 
 class GrpcProfileTaskChannelService(ProfileTaskChannelService):

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -22,10 +22,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import List
 
-# In order to prevent timeouts and possible segment loss make sure QUEUE_TIMEOUT is always at least few seconds lower
-# than GRPC_TIMEOUT.
-GRPC_TIMEOUT = 300  # type: int
-QUEUE_TIMEOUT = 240  # type: int
+QUEUE_TIMEOUT = 1  # type: int
 
 RE_IGNORE_PATH = re.compile('^$')  # type: re.Pattern
 
@@ -41,6 +38,7 @@ protocol = (os.getenv('SW_AGENT_PROTOCOL') or 'grpc').lower()  # type: str
 authentication = os.getenv('SW_AGENT_AUTHENTICATION')  # type: str
 logging_level = os.getenv('SW_AGENT_LOGGING_LEVEL') or 'INFO'  # type: str
 disable_plugins = (os.getenv('SW_AGENT_DISABLE_PLUGINS') or '').split(',')  # type: List[str]
+max_buffer_size = int(os.getenv('SW_AGENT_MAX_BUFFER_SIZE', '1000'))  # type: int
 sql_parameters_length = int(os.getenv('SW_SQL_PARAMETERS_LENGTH') or '0')  # type: int
 pymongo_trace_parameters = True if os.getenv('SW_PYMONGO_TRACE_PARAMETERS') and \
                                    os.getenv('SW_PYMONGO_TRACE_PARAMETERS') == 'True' else False  # type: bool

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -269,4 +269,4 @@ def get_context() -> SpanContext:
     if spans:
         return spans[len(spans) - 1].context
 
-    return SpanContext() if agent.connected() else NoopContext()
+    return SpanContext()


### PR DESCRIPTION
Discovered this issue while using grpc_proxy in nginx, doesn't seem to happen when connecting directly to grpc server. The presence of the `connected()` protocol method could lead to a deadlock where grpc was disconnected and because of this no other calls to it would be made to reconnect. This is because both the heartbeat and creation of `SpanContext()`s instead of `NoopContext()`s (which would lead to a `report()`) depended on `connected()` being True.

* For this reason removed the `connected()` method entirely since it doesn't even apply to the two other protocols - http and kafka.

* Set `__finished.wait(0)` in the report thread instead of blocking for 3 or 30 seconds because this could be detrimental in high throughput scenarios. Now the only report thread blocking that happens in is the report generators of the various protocols waiting on the queue.

* Also wrapped the various threaded protocol calls in try / except in order to prevent unexpected transient exceptions from killing the threads.

* Added SW_AGENT_MAX_BUFFER_SIZE which sets the maximum queue length like in the Node agent.