### PR TITLE
cleanup: remove unused methods

### DIFF
--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -96,14 +96,3 @@ def finalize():
 
     global RE_IGNORE_PATH
     RE_IGNORE_PATH = re.compile('%s|%s' % (suffix, path))
-
-
-def serialize():
-    glob = globals()
-
-    return {key: glob[key] for key in options}
-
-
-def deserialize(data):
-    init(**data)
-    finalize()

--- a/tests/plugin/sw_rabbitmq/docker-compose.yml
+++ b/tests/plugin/sw_rabbitmq/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       file: ../docker/docker-compose.base.yml
 
   rabbitmq-server:
-    image: rabbitmq:latest
+    image: rabbitmq:3.8.18
     hostname: rabbitmq-server
     ports:
       - 5672:5672


### PR DESCRIPTION
`serialize` and `deserialize` were used in `SwProcess` and now it's removed we should also remove them