### PR TITLE
NoopSpan on queue full, propagation downstream

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -168,6 +168,10 @@ def started():
     return __started
 
 
+def isfull():
+    return __queue.full()
+
+
 def archive(segment: 'Segment'):
     try:  # unlike checking __queue.full() then inserting, this is atomic
         __queue.put(segment, block=False)

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -41,7 +41,8 @@ def install():
             span.layer = Layer.Http
             code = None
 
-            [fullurl.add_header(item.key, item.val) for item in carrier]
+            for item in carrier:
+                fullurl.add_header(item.key, item.val)
 
             try:
                 res = _open(this, fullurl, data, timeout)

--- a/skywalking/trace/carrier.py
+++ b/skywalking/trace/carrier.py
@@ -48,6 +48,7 @@ class Carrier(CarrierItem):
                  service_instance: str = '', endpoint: str = '', client_address: str = '',
                  correlation: dict = None):  # pyre-ignore
         super(Carrier, self).__init__(key='sw8')
+        self.__val = None
         self.trace_id = trace_id  # type: str
         self.segment_id = segment_id  # type: str
         self.span_id = span_id  # type: str
@@ -100,6 +101,10 @@ class Carrier(CarrierItem):
                len(self.endpoint) > 0 and \
                len(self.client_address) > 0 and \
                self.span_id.isnumeric()
+
+    @property
+    def is_suppressed(self):  # if is invalid from previous set, ignored or suppressed status propagation downstream
+        return self.__val and not self.is_valid
 
     def __iter__(self):
         self.__iter_index = 0

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -220,12 +220,11 @@ class ExitSpan(Span):
 
 @tostring
 class NoopSpan(Span):
-    def __init__(self, context: 'SpanContext' = None, kind: 'Kind' = None):
-        Span.__init__(self, context=context, kind=kind)
+    def __init__(self, context: 'SpanContext' = None):
+        Span.__init__(self, context=context, op='', kind=Kind.Local)
 
     def extract(self, carrier: 'Carrier'):
-        if carrier is not None:
-            self.context._correlation = carrier.correlation_carrier.correlation
+        return
 
     def inject(self) -> 'Carrier':
-        return Carrier(correlation=self.context._correlation)
+        return Carrier()


### PR DESCRIPTION
This has two things similar to the Node agent PR 50, it has:
* Spans which are ignored due to suffix or endpoint name pattern match will propagate their ignored status downstream via noop span and sending an empty "sw8" header. If such an empty header is received then a dummy context and span is created instead of a new actively traced segment. This is only a behavior change for this agent and is compatible with other language agents, they will just act as they have always done. The Node agent already has this behavior so will ignore spans ignored by this agent and vice-versa.
* The method of limiting the number of segments which are recorded has been changed from post-record check to pre-record check to avoid unnecessary instrumentation if the number of segments already exceeds the threshold and the data would be thrown away anyway. This also allows propagation of ignored status of segment downstream via mechanism described above to avoid broken "VNode" segments in trace view.

And the minor little detail in `sw_urllib_request`, the change from:
```py
[fullurl.add_header(item.key, item.val) for item in carrier]
```
To:
```py
for item in carrier:
    fullurl.add_header(item.key, item.val)
```
The first form is not ideal since it actually creates the intermediate list object from the comprehension unnecessarily.