### PR TITLE
Cleaned up Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ with context.new_entry_span(op='https://github.com/apache') as span:
     span.component = Component.Flask
 # the span automatically stops when exiting the `with` context
 
+class TagSinger(Tag):
+    key = 'Singer'
+
 with context.new_exit_span(op='https://github.com/apache', peer='localhost:8080', component=Component.Flask) as span:
-    span.tag(Tag(key='Singer', val='Nakajima'))
+    span.tag(TagSinger('Nakajima'))
 
 with context.new_local_span(op='https://github.com/apache') as span:
-    span.tag(Tag(key='Singer', val='Nakajima'))
+    span.tag(TagSinger('Nakajima'))
 ```
 
 ### Decorators

--- a/docs/EnvVars.md
+++ b/docs/EnvVars.md
@@ -11,7 +11,8 @@ Environment Variable | Description | Default
 | `SW_AGENT_AUTHENTICATION` | The authentication token to verify that the agent is trusted by the backend OAP, as for how to configure the backend, refer to [the yaml](https://github.com/apache/skywalking/blob/4f0f39ffccdc9b41049903cc540b8904f7c9728e/oap-server/server-bootstrap/src/main/resources/application.yml#L155-L158). | unset |
 | `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `CRITICAL`, `FATAL`, `ERROR`, `WARN`(`WARNING`), `INFO`, `DEBUG` | `INFO` |
 | `SW_AGENT_DISABLE_PLUGINS` | The name patterns in CSV pattern, plugins whose name matches one of the pattern won't be installed | `''` |
-| `SW_AGENT_MAX_BUFFER_SIZE` | The maximum queue backlog size for sending the segment data to backend, segments beyond this are silently dropped | `'1000'` |
+| `SW_AGENT_MAX_BUFFER_SIZE` | The maximum queue backlog size for sending the segment data to backend, segments beyond this are silently dropped | `'10000'` |
+| `SW_HTTP_IGNORE_METHOD` | Comma-delimited list of http methods to ignore (GET, POST, HEAD, OPTIONS, etc...) | `` |
 | `SW_SQL_PARAMETERS_LENGTH` | The maximum length of the collected parameter, parameters longer than the specified length will be truncated, length 0 turns off parameter tracing | `0` |
 | `SW_PYMONGO_TRACE_PARAMETERS` | Indicates whether to collect the filters of pymongo | `False` |
 | `SW_PYMONGO_PARAMETERS_MAX_LENGTH` | The maximum length of the collected filters, filters longer than the specified length will be truncated |  `512` |

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -115,9 +115,9 @@ class GrpcProtocol(Protocol):
                             data=[KeyStringValuePair(key=item.key, value=item.val) for item in log.items],
                         ) for log in span.logs],
                         tags=[KeyStringValuePair(
-                            key=str(tag.key),
+                            key=tag.key,
                             value=str(tag.val),
-                        ) for tag in span.tags],
+                        ) for tag in span.iter_tags()],
                         refs=[SegmentReference(
                             refType=0 if ref.ref_type == "CrossProcess" else 1,
                             traceId=ref.trace_id,

--- a/skywalking/agent/protocol/kafka.py
+++ b/skywalking/agent/protocol/kafka.py
@@ -78,9 +78,9 @@ class KafkaProtocol(Protocol):
                             data=[KeyStringValuePair(key=item.key, value=item.val) for item in log.items],
                         ) for log in span.logs],
                         tags=[KeyStringValuePair(
-                            key=str(tag.key),
+                            key=tag.key,
                             value=str(tag.val),
-                        ) for tag in span.tags],
+                        ) for tag in span.iter_tags()],
                         refs=[SegmentReference(
                             refType=0 if ref.ref_type == "CrossProcess" else 1,
                             traceId=ref.trace_id,

--- a/skywalking/client/http.py
+++ b/skywalking/client/http.py
@@ -95,7 +95,7 @@ class HttpTraceSegmentReportService(TraceSegmentReportService):
                     'tags': [{
                         'key': tag.key,
                         'value': tag.val,
-                    } for tag in span.tags],
+                    } for tag in span.iter_tags()],
                     'refs': [{
                         'refType': 0,
                         'traceId': ref.trace_id,

--- a/skywalking/decorators.py
+++ b/skywalking/decorators.py
@@ -40,7 +40,9 @@ def trace(
                 span = context.new_local_span(op=_op)
                 span.layer = layer
                 span.component = component
-                [span.tag(tag) for tag in tags or []]
+                if tags:
+                    for tag in tags:
+                        span.tag(tag)
                 with span:
                     return await func(*args, **kwargs)
             return wrapper
@@ -52,7 +54,9 @@ def trace(
                 span = context.new_local_span(op=_op)
                 span.layer = layer
                 span.component = component
-                [span.tag(tag) for tag in tags or []]
+                if tags:
+                    for tag in tags:
+                        span.tag(tag)
                 with span:
                     return func(*args, **kwargs)
             return wrapper
@@ -77,7 +81,9 @@ def runnable(
                 context.continued(snapshot)
                 span.layer = layer
                 span.component = component
-                [span.tag(tag) for tag in tags or []]
+                if tags:
+                    for tag in tags:
+                        span.tag(tag)
                 func(*args, **kwargs)
 
         return wrapper

--- a/skywalking/plugins/sw_aiohttp.py
+++ b/skywalking/plugins/sw_aiohttp.py
@@ -16,11 +16,10 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -38,8 +37,8 @@ def install():
 
         with span:
             span.layer = Layer.Http
-            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))  # pyre-ignore
-            span.tag(Tag(key=tags.HttpUrl, val=url))  # pyre-ignore
+            span.tag(TagHttpMethod(method.upper()))  # pyre-ignore
+            span.tag(TagHttpURL(url))  # pyre-ignore
 
             carrier = span.inject()
             headers = kwargs.get('headers')
@@ -54,7 +53,7 @@ def install():
 
             res = await _request(self, method, str_or_url, **kwargs)
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.status, overridable=True))
+            span.tag(TagHttpStatusCode(res.status))
 
             if res.status >= 400:
                 span.error_occurred = True
@@ -83,12 +82,12 @@ def install():
             span.peer = '%s:%d' % request._transport_peername if isinstance(request._transport_peername, (list, tuple))\
                 else request._transport_peername
 
-            span.tag(Tag(key=tags.HttpMethod, val=method))  # pyre-ignore
-            span.tag(Tag(key=tags.HttpUrl, val=str(request.url)))  # pyre-ignore
+            span.tag(TagHttpMethod(method))  # pyre-ignore
+            span.tag(TagHttpURL(str(request.url)))  # pyre-ignore
 
             resp, reset = await _handle_request(self, request, start_time)
 
-            span.tag(Tag(key=tags.HttpStatus, val=resp.status, overridable=True))
+            span.tag(TagHttpStatusCode(resp.status))
 
             if resp.status >= 400:
                 span.error_occurred = True

--- a/skywalking/plugins/sw_celery.py
+++ b/skywalking/plugins/sw_celery.py
@@ -16,10 +16,9 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagMqBroker, TagCeleryParameters
 
 
 def install():
@@ -45,13 +44,13 @@ def install():
         with get_context().new_exit_span(op=op, peer=peer, component=Component.Celery) as span:
             span.layer = Layer.MQ
 
-            span.tag(Tag(key=tags.MqBroker, val=broker_url))
-            # span.tag(Tag(key=tags.MqTopic, val=exchange))
-            # span.tag(Tag(key=tags.MqQueue, val=queue))
+            span.tag(TagMqBroker(broker_url))
+            # span.tag(TagMqTopic(exchange))
+            # span.tag(TagMqQueue(queue))
 
             if config.celery_parameters_length:
                 params = '*{}, **{}'.format(args, kwargs)[:config.celery_parameters_length]
-                span.tag(Tag(key=tags.CeleryParameters, val=params))
+                span.tag(TagCeleryParameters(params))
 
             options = {**options}
             headers = options.get('headers')
@@ -95,13 +94,13 @@ def install():
                 span.layer = Layer.MQ
                 span.component = Component.Celery
 
-                span.tag(Tag(key=tags.MqBroker, val=task.app.conf['broker_url']))
-                # span.tag(Tag(key=tags.MqTopic, val=exchange))
-                # span.tag(Tag(key=tags.MqQueue, val=queue))
+                span.tag(TagMqBroker(task.app.conf['broker_url']))
+                # span.tag(TagMqTopic(exchange))
+                # span.tag(TagMqQueue(queue))
 
                 if config.celery_parameters_length:
                     params = '*{}, **{}'.format(args, kwargs)[:config.celery_parameters_length]
-                    span.tag(Tag(key=tags.CeleryParameters, val=params))
+                    span.tag(TagCeleryParameters(params))
 
                 return _fun(*args, **kwargs)
 

--- a/skywalking/plugins/sw_elasticsearch.py
+++ b/skywalking/plugins/sw_elasticsearch.py
@@ -16,9 +16,8 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagDbType, TagDbStatement
 
 
 def install():
@@ -33,9 +32,9 @@ def install():
             span.layer = Layer.Database
             res = _perform_request(this, method, url, headers=headers, params=params, body=body)
 
-            span.tag(Tag(key=tags.DbType, val="Elasticsearch"))
+            span.tag(TagDbType("Elasticsearch"))
             if config.elasticsearch_trace_dsl:
-                span.tag(Tag(key=tags.DbStatement, val="" if body is None else body))
+                span.tag(TagDbStatement("" if body is None else body))
 
             return res
 

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -16,11 +16,10 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, TagHttpParams
 
 
 def install():
@@ -50,17 +49,16 @@ def install():
             span.layer = Layer.Http
             span.component = Component.Flask
             span.peer = '%s:%s' % (req.environ["REMOTE_ADDR"], req.environ["REMOTE_PORT"])
-            span.tag(Tag(key=tags.HttpMethod, val=method))
-            span.tag(Tag(key=tags.HttpUrl, val=req.url.split("?")[0]))
+            span.tag(TagHttpMethod(method))
+            span.tag(TagHttpURL(req.url.split("?")[0]))
             if config.flask_collect_http_params and req.values:
-                span.tag(Tag(key=tags.HttpParams,
-                             val=params_tostring(req.values)[0:config.http_params_length_threshold]))
+                span.tag(TagHttpParams(params_tostring(req.values)[0:config.http_params_length_threshold]))
             resp = _full_dispatch_request(this)
 
             if resp.status_code >= 400:
                 span.error_occurred = True
 
-            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code, overridable=True))
+            span.tag(TagHttpStatusCode(resp.status_code))
             return resp
 
     def _sw_handle_user_exception(this: Flask, e):

--- a/skywalking/plugins/sw_http_server.py
+++ b/skywalking/plugins/sw_http_server.py
@@ -18,11 +18,10 @@
 import inspect
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -71,15 +70,15 @@ def wrap_werkzeug_request_handler(handler):
             span.layer = Layer.Http
             span.component = Component.General
             span.peer = '%s:%s' % handler.client_address
-            span.tag(Tag(key=tags.HttpMethod, val=method))
-            span.tag(Tag(key=tags.HttpUrl, val=url))
+            span.tag(TagHttpMethod(method))
+            span.tag(TagHttpURL(url))
 
             try:
                 return _run_wsgi()
             finally:
                 status_code = int(getattr(handler, '_status_code', -1))
                 if status_code > -1:
-                    span.tag(Tag(key=tags.HttpStatus, val=status_code, overridable=True))
+                    span.tag(TagHttpStatusCode(status_code))
                     if status_code >= 400:
                         span.error_occurred = True
 
@@ -122,15 +121,15 @@ def _wrap_do_method(handler, method):
                 span.layer = Layer.Http
                 span.component = Component.General
                 span.peer = '%s:%s' % handler.client_address
-                span.tag(Tag(key=tags.HttpMethod, val=method))
-                span.tag(Tag(key=tags.HttpUrl, val=url))
+                span.tag(TagHttpMethod(method))
+                span.tag(TagHttpURL(url))
 
                 try:
                     _do_method()
                 finally:
                     status_code = int(getattr(handler, '_status_code', -1))
                     if status_code > -1:
-                        span.tag(Tag(key=tags.HttpStatus, val=status_code, overridable=True))
+                        span.tag(TagHttpStatusCode(status_code))
                         if status_code >= 400:
                             span.error_occurred = True
 

--- a/skywalking/plugins/sw_kafka.py
+++ b/skywalking/plugins/sw_kafka.py
@@ -17,10 +17,9 @@
 
 from skywalking import config
 from skywalking import Layer, Component
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagMqBroker, TagMqTopic
 
 
 def install():
@@ -53,8 +52,8 @@ def _sw__poll_once_func(__poll_once):
                                     item.val = str(header[1])
 
                         span.extract(carrier)
-                    span.tag(Tag(key=tags.MqBroker, val=brokers))
-                    span.tag(Tag(key=tags.MqTopic, val=topics))
+                    span.tag(TagMqBroker(brokers))
+                    span.tag(TagMqTopic(topics))
                     span.layer = Layer.MQ
                     span.component = Component.KafkaConsumer
 
@@ -84,8 +83,8 @@ def _sw_send_func(_send):
 
             res = _send(this, topic, value=value, key=key, headers=headers, partition=partition,
                         timestamp_ms=timestamp_ms)
-            span.tag(Tag(key=tags.MqBroker, val=peer))
-            span.tag(Tag(key=tags.MqTopic, val=topic))
+            span.tag(TagMqBroker(peer))
+            span.tag(TagMqTopic(topic))
 
             return res
 

--- a/skywalking/plugins/sw_psycopg2.py
+++ b/skywalking/plugins/sw_psycopg2.py
@@ -16,9 +16,8 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagDbType, TagDbInstance, TagDbStatement, TagDbSqlParameters
 
 
 def install():
@@ -42,9 +41,9 @@ def install():
                                              component=Component.Psycopg) as span:
                 span.layer = Layer.Database
 
-                span.tag(Tag(key=tags.DbType, val="PostgreSQL"))
-                span.tag(Tag(key=tags.DbInstance, val=dsn['dbname']))
-                span.tag(Tag(key=tags.DbStatement, val=query))
+                span.tag(TagDbType("PostgreSQL"))
+                span.tag(TagDbInstance(dsn['dbname']))
+                span.tag(TagDbStatement(query))
 
                 if config.sql_parameters_length and vars is not None:
                     text = ','.join(str(v) for v in vars)
@@ -52,7 +51,7 @@ def install():
                     if len(text) > config.sql_parameters_length:
                         text = text[:config.sql_parameters_length] + '...'
 
-                    span.tag(Tag(key=tags.DbSqlParameters, val='[' + text + ']'))
+                    span.tag(TagDbSqlParameters('[' + text + ']'))
 
                 return self._self_cur.execute(query, vars)
 
@@ -64,9 +63,9 @@ def install():
                                              component=Component.Psycopg) as span:
                 span.layer = Layer.Database
 
-                span.tag(Tag(key=tags.DbType, val="PostgreSQL"))
-                span.tag(Tag(key=tags.DbInstance, val=dsn['dbname']))
-                span.tag(Tag(key=tags.DbStatement, val=query))
+                span.tag(TagDbType("PostgreSQL"))
+                span.tag(TagDbInstance(dsn['dbname']))
+                span.tag(TagDbStatement(query))
 
                 if config.sql_parameters_length:
                     max_len = config.sql_parameters_length
@@ -84,7 +83,7 @@ def install():
 
                         text_list.append(text)
 
-                    span.tag(Tag(key=tags.DbSqlParameters, val='[' + ','.join(text_list) + ']'))
+                    span.tag(TagDbSqlParameters('[' + ','.join(text_list) + ']'))
 
                 return self._self_cur.executemany(query, vars_list)
 
@@ -97,9 +96,9 @@ def install():
                 span.layer = Layer.Database
                 args = '(' + ('' if not parameters else ','.join(parameters)) + ')'
 
-                span.tag(Tag(key=tags.DbType, val="PostgreSQL"))
-                span.tag(Tag(key=tags.DbInstance, val=dsn['dbname']))
-                span.tag(Tag(key=tags.DbStatement, val=procname + args))
+                span.tag(TagDbType("PostgreSQL"))
+                span.tag(TagDbInstance(dsn['dbname']))
+                span.tag(TagDbStatement(procname + args))
 
                 return self._self_cur.callproc(procname, parameters)
 

--- a/skywalking/plugins/sw_pymongo.py
+++ b/skywalking/plugins/sw_pymongo.py
@@ -16,9 +16,8 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagDbType, TagDbInstance, TagDbStatement
 
 version_rule = {
     "name": "pymongo",
@@ -62,15 +61,15 @@ def inject_socket_info(SocketInfo):
                 result = _command(this, dbname, spec, *args, **kwargs)
 
                 span.layer = Layer.Database
-                span.tag(Tag(key=tags.DbType, val="MongoDB"))
-                span.tag(Tag(key=tags.DbInstance, val=dbname))
+                span.tag(TagDbType("MongoDB"))
+                span.tag(TagDbInstance(dbname))
 
                 if config.pymongo_trace_parameters:
                     # get filters
                     filters = _get_filter(operation, spec)
                     max_len = config.pymongo_parameters_max_length
                     filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                    span.tag(Tag(key=tags.DbStatement, val=filters))
+                    span.tag(TagDbStatement(filters))
 
         else:
             result = _command(this, dbname, spec, *args, **kwargs)
@@ -112,8 +111,8 @@ def inject_bulk_write(_Bulk, bulk_op_map):
 
             bulk_result = _execute(this, *args, **kwargs)
 
-            span.tag(Tag(key=tags.DbType, val="MongoDB"))
-            span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
+            span.tag(TagDbType("MongoDB"))
+            span.tag(TagDbInstance(this.collection.database.name))
             if config.pymongo_trace_parameters:
                 filters = ""
                 bulk_ops = this.ops
@@ -124,7 +123,7 @@ def inject_bulk_write(_Bulk, bulk_op_map):
 
                 max_len = config.pymongo_parameters_max_length
                 filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                span.tag(Tag(key=tags.DbStatement, val=filters))
+                span.tag(TagDbStatement(filters))
 
             return bulk_result
 
@@ -147,14 +146,14 @@ def inject_cursor(Cursor):
             # __send_message return nothing
             __send_message(this, operation)
 
-            span.tag(Tag(key=tags.DbType, val="MongoDB"))
-            span.tag(Tag(key=tags.DbInstance, val=this.collection.database.name))
+            span.tag(TagDbType("MongoDB"))
+            span.tag(TagDbInstance(this.collection.database.name))
 
             if config.pymongo_trace_parameters:
                 filters = "find " + str(operation.spec)
                 max_len = config.pymongo_parameters_max_length
                 filters = filters[0:max_len] + "..." if len(filters) > max_len else filters
-                span.tag(Tag(key=tags.DbStatement, val=filters))
+                span.tag(TagDbStatement(filters))
 
             return
 

--- a/skywalking/plugins/sw_pymysql.py
+++ b/skywalking/plugins/sw_pymysql.py
@@ -16,9 +16,8 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagDbType, TagDbInstance, TagDbStatement, TagDbSqlParameters
 
 
 def install():
@@ -34,15 +33,15 @@ def install():
             span.layer = Layer.Database
             res = _execute(this, query, args)
 
-            span.tag(Tag(key=tags.DbType, val="mysql"))
-            span.tag(Tag(key=tags.DbInstance, val=(this.connection.db or b'').decode("utf-8")))
-            span.tag(Tag(key=tags.DbStatement, val=query))
+            span.tag(TagDbType("mysql"))
+            span.tag(TagDbInstance((this.connection.db or b'').decode("utf-8")))
+            span.tag(TagDbStatement(query))
 
             if config.sql_parameters_length and args:
                 parameter = ",".join([str(arg) for arg in args])
                 max_len = config.sql_parameters_length
                 parameter = parameter[0:max_len] + "..." if len(parameter) > max_len else parameter
-                span.tag(Tag(key=tags.DbSqlParameters, val='[' + parameter + ']'))
+                span.tag(TagDbSqlParameters('[' + parameter + ']'))
 
             return res
 

--- a/skywalking/plugins/sw_pyramid.py
+++ b/skywalking/plugins/sw_pyramid.py
@@ -16,11 +16,10 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -44,12 +43,12 @@ def install():
             span.component = Component.Pyramid
             span.peer = request.remote_host or request.remote_addr
 
-            span.tag(Tag(key=tags.HttpMethod, val=method))
-            span.tag(Tag(key=tags.HttpUrl, val=str(request.url)))
+            span.tag(TagHttpMethod(method))
+            span.tag(TagHttpURL(str(request.url)))
 
             resp = _invoke_request(self, request, *args, **kwargs)
 
-            span.tag(Tag(key=tags.HttpStatus, val=resp.status_code, overridable=True))
+            span.tag(TagHttpStatusCode(resp.status_code))
 
             if resp.status_code >= 400:
                 span.error_occurred = True

--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -16,10 +16,9 @@
 #
 
 from skywalking import Layer, Component
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagMqBroker, TagMqTopic, TagMqQueue
 
 
 def install():
@@ -56,9 +55,9 @@ def _sw_basic_publish_func(_basic_publish):
                                  body,
                                  properties=properties,
                                  mandatory=mandatory)
-            span.tag(Tag(key=tags.MqBroker, val=peer))
-            span.tag(Tag(key=tags.MqTopic, val=exchange))
-            span.tag(Tag(key=tags.MqQueue, val=routing_key))
+            span.tag(TagMqBroker(peer))
+            span.tag(TagMqTopic(exchange))
+            span.tag(TagMqQueue(routing_key))
 
             return res
 
@@ -81,8 +80,8 @@ def _sw__on_deliver_func(__on_deliver):
             span.layer = Layer.MQ
             span.component = Component.RabbitmqConsumer
             __on_deliver(this, method_frame, header_frame, body)
-            span.tag(Tag(key=tags.MqBroker, val=peer))
-            span.tag(Tag(key=tags.MqTopic, val=exchange))
-            span.tag(Tag(key=tags.MqQueue, val=routing_key))
+            span.tag(TagMqBroker(peer))
+            span.tag(TagMqTopic(exchange))
+            span.tag(TagMqQueue(routing_key))
 
     return _sw__on_deliver

--- a/skywalking/plugins/sw_redis.py
+++ b/skywalking/plugins/sw_redis.py
@@ -16,9 +16,8 @@
 #
 
 from skywalking import Layer, Component
-from skywalking.trace import tags
 from skywalking.trace.context import get_context
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagDbType, TagDbInstance, TagDbStatement
 
 
 def install():
@@ -34,9 +33,9 @@ def install():
             span.layer = Layer.Cache
 
             res = _send_command(this, *args, **kwargs)
-            span.tag(Tag(key=tags.DbType, val="Redis"))
-            span.tag(Tag(key=tags.DbInstance, val=this.db))
-            span.tag(Tag(key=tags.DbStatement, val=op))
+            span.tag(TagDbType("Redis"))
+            span.tag(TagDbInstance(this.db))
+            span.tag(TagDbStatement(op))
 
             return res
 

--- a/skywalking/plugins/sw_requests.py
+++ b/skywalking/plugins/sw_requests.py
@@ -16,10 +16,9 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -55,15 +54,15 @@ def install():
             for item in carrier:
                 headers[item.key] = item.val
 
-            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
-            span.tag(Tag(key=tags.HttpUrl, val=url))
+            span.tag(TagHttpMethod(method.upper()))
+            span.tag(TagHttpURL(url))
 
             res = _request(this, method, url, params, data, headers, cookies, files, auth, timeout,
                            allow_redirects,
                            proxies,
                            hooks, stream, verify, cert, json)
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.status_code, overridable=True))
+            span.tag(TagHttpStatusCode(res.status_code))
             if res.status_code >= 400:
                 span.error_occurred = True
 

--- a/skywalking/plugins/sw_sanic.py
+++ b/skywalking/plugins/sw_sanic.py
@@ -17,11 +17,10 @@
 import logging
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, TagHttpParams
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ def install():
             if entry_span is not None and type(entry_span) is not NoopSpan:
                 if status >= 400:
                     entry_span.error_occurred = True
-                entry_span.tag(Tag(key=tags.HttpStatus, val=status))
+                entry_span.tag(TagHttpStatusCode(status))
 
         return _format_http1_response(status, headers, body)
 
@@ -83,11 +82,10 @@ def _gen_sw_handle_request(_handle_request):
             span.layer = Layer.Http
             span.component = Component.Sanic
             span.peer = '%s:%s' % (req.remote_addr or req.ip, req.port)
-            span.tag(Tag(key=tags.HttpMethod, val=method))
-            span.tag(Tag(key=tags.HttpUrl, val=req.url.split("?")[0]))
+            span.tag(TagHttpMethod(method))
+            span.tag(TagHttpURL(req.url.split("?")[0]))
             if config.sanic_collect_http_params and req.args:
-                span.tag(Tag(key=tags.HttpParams,
-                             val=params_tostring(req.args)[0:config.http_params_length_threshold]))
+                span.tag(TagHttpParams(params_tostring(req.args)[0:config.http_params_length_threshold]))
             resp = _handle_request(self, request, write_callback, stream_callback)
             if isawaitable(resp):
                 result = await resp

--- a/skywalking/plugins/sw_tornado.py
+++ b/skywalking/plugins/sw_tornado.py
@@ -18,11 +18,10 @@
 from inspect import iscoroutinefunction, isawaitable
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 version_rule = {
     "name": "tornado",
@@ -71,13 +70,12 @@ def _gen_sw_get_response_func(old_execute):
                 span.component = Component.Tornado
                 peer = request.connection.stream.socket.getpeername()
                 span.peer = '{0}:{1}'.format(*peer)
-                span.tag(Tag(key=tags.HttpMethod, val=method))
-                span.tag(
-                    Tag(key=tags.HttpUrl, val='{}://{}{}'.format(request.protocol, request.host, request.path)))
+                span.tag(TagHttpMethod(method))
+                span.tag(TagHttpURL('{}://{}{}'.format(request.protocol, request.host, request.path)))
                 result = old_execute(self, *args, **kwargs)
                 if isawaitable(result):
                     result = await result
-                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
+                span.tag(TagHttpStatusCode(self._status_code))
                 if self._status_code >= 400:
                     span.error_occurred = True
             return result
@@ -100,11 +98,10 @@ def _gen_sw_get_response_func(old_execute):
                 span.component = Component.Tornado
                 peer = request.connection.stream.socket.getpeername()
                 span.peer = '{0}:{1}'.format(*peer)
-                span.tag(Tag(key=tags.HttpMethod, val=method))
-                span.tag(
-                    Tag(key=tags.HttpUrl, val='{}://{}{}'.format(request.protocol, request.host, request.path)))
+                span.tag(TagHttpMethod(method))
+                span.tag(TagHttpURL('{}://{}{}'.format(request.protocol, request.host, request.path)))
                 result = yield from old_execute(self, *args, **kwargs)
-                span.tag(Tag(key=tags.HttpStatus, val=self._status_code, overridable=True))
+                span.tag(TagHttpStatusCode(self._status_code))
                 if self._status_code >= 400:
                     span.error_occurred = True
             return result

--- a/skywalking/plugins/sw_urllib3.py
+++ b/skywalking/plugins/sw_urllib3.py
@@ -16,10 +16,9 @@
 #
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -45,12 +44,12 @@ def install():
             for item in carrier:
                 headers[item.key] = item.val
 
-            span.tag(Tag(key=tags.HttpMethod, val=method.upper()))
-            span.tag(Tag(key=tags.HttpUrl, val=url))
+            span.tag(TagHttpMethod(method.upper()))
+            span.tag(TagHttpURL(url))
 
             res = _request(this, method, url, fields=fields, headers=headers, **urlopen_kw)
 
-            span.tag(Tag(key=tags.HttpStatus, val=res.status, overridable=True))
+            span.tag(TagHttpStatusCode(res.status))
             if res.status >= 400:
                 span.error_occurred = True
 

--- a/skywalking/plugins/sw_urllib_request.py
+++ b/skywalking/plugins/sw_urllib_request.py
@@ -18,10 +18,9 @@
 from urllib.request import Request
 
 from skywalking import Layer, Component, config
-from skywalking.trace import tags
 from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import Tag
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
 
 
 def install():
@@ -56,11 +55,11 @@ def install():
                 code = e.code
                 raise
             finally:  # we do this here because it may change in _open()
-                span.tag(Tag(key=tags.HttpMethod, val=method))
-                span.tag(Tag(key=tags.HttpUrl, val=fullurl.full_url))
+                span.tag(TagHttpMethod(method))
+                span.tag(TagHttpURL(fullurl.full_url))
 
                 if code is not None:
-                    span.tag(Tag(key=tags.HttpStatus, val=code, overridable=True))
+                    span.tag(TagHttpStatusCode(code))
 
                     if code >= 400:
                         span.error_occurred = True

--- a/skywalking/trace/tags.py
+++ b/skywalking/trace/tags.py
@@ -15,20 +15,57 @@
 # limitations under the License.
 #
 
-from collections import namedtuple
+class Tag:
+    overridable = True
 
-Tag = namedtuple('Tag', 'key val overridable')
-Tag.__new__.__defaults__ = (None, None, False)
+    def __init__(self, val):
+        self.val = val
 
-HttpUrl = 'url'
-HttpMethod = 'http.method'
-HttpStatus = 'status.code'
-DbType = 'db.type'
-DbInstance = 'db.instance'
-DbStatement = 'db.statement'
-DbSqlParameters = 'db.sql.parameters'
-HttpParams = 'http.params'
-MqBroker = 'mq.broker'
-MqTopic = 'mq.topic'
-MqQueue = 'mq.queue'
-CeleryParameters = 'celery.parameters'
+
+class TagHttpMethod(Tag):
+    key = 'http.method'
+
+
+class TagHttpURL(Tag):
+    key = 'http.url'
+
+
+class TagHttpStatusCode(Tag):
+    key = 'http.status.code'
+
+
+class TagHttpParams(Tag):
+    key = 'http.params'
+
+
+class TagDbType(Tag):
+    key = 'db.type'
+
+
+class TagDbInstance(Tag):
+    key = 'db.instance'
+
+
+class TagDbStatement(Tag):
+    key = 'db.statement'
+
+
+class TagDbSqlParameters(Tag):
+    key = 'db.sql.parameters'
+    overridable = False
+
+
+class TagMqBroker(Tag):
+    key = 'mq.broker'
+
+
+class TagMqTopic(Tag):
+    key = 'mq.topic'
+
+
+class TagMqQueue(Tag):
+    key = 'mq.queue'
+
+
+class TagCeleryParameters(Tag):
+    key = 'celery.parameters'

--- a/tests/plugin/sw_aiohttp/expected.data.yml
+++ b/tests/plugin/sw_aiohttp/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/skywalking
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /skywalking
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/skywalking
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/skywalking
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_django/expected.data.yml
+++ b/tests/plugin/sw_django/expected.data.yml
@@ -35,9 +35,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -67,9 +67,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /users
             operationId: 0
@@ -85,9 +85,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
               - key: http.params
                 value: "test=[test1,test2]\ntest2=[test2]"
-              - key: status.code
+              - key: http.status.code
                 value: '200'

--- a/tests/plugin/sw_elasticsearch/expected.data.yml
+++ b/tests/plugin/sw_elasticsearch/expected.data.yml
@@ -80,9 +80,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_flask/expected.data.yml
+++ b/tests/plugin/sw_flask/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -58,9 +58,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -97,9 +97,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: 'http://provider:9091/users'
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /test
             operationId: 0
@@ -132,9 +132,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -150,11 +150,11 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
               - key: http.params
                 value: "test=[test1,test2]\ntest2=[test2]"
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_http/expected.data.yml
+++ b/tests/plugin/sw_http/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_http_wsgi/expected.data.yml
+++ b/tests/plugin/sw_http_wsgi/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_kafka/expected.data.yml
+++ b/tests/plugin/sw_kafka/expected.data.yml
@@ -45,9 +45,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_psycopg2/expected.data.yml
+++ b/tests/plugin/sw_psycopg2/expected.data.yml
@@ -50,9 +50,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -82,9 +82,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -101,9 +101,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_pymongo/expected.data.yml
+++ b/tests/plugin/sw_pymongo/expected.data.yml
@@ -53,9 +53,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/insert_many
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /insert_many
@@ -100,9 +100,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/find_one
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /find_one
@@ -147,9 +147,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/delete_one
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /delete_one
@@ -179,9 +179,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/insert_many
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /find_one
             operationId: 0
@@ -197,9 +197,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/find_one
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /delete_one
             operationId: 0
@@ -215,9 +215,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/delete_one
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /users
             operationId: 0
@@ -233,7 +233,7 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'

--- a/tests/plugin/sw_pymysql/expected.data.yml
+++ b/tests/plugin/sw_pymysql/expected.data.yml
@@ -49,9 +49,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -81,9 +81,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -99,9 +99,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_pyramid/expected.data.yml
+++ b/tests/plugin/sw_pyramid/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/pyramid
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /pyramid
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/pyramid
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/pyramid
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_rabbitmq/expected.data.yml
+++ b/tests/plugin/sw_rabbitmq/expected.data.yml
@@ -47,9 +47,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_redis/expected.data.yml
+++ b/tests/plugin/sw_redis/expected.data.yml
@@ -65,9 +65,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -97,9 +97,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -115,9 +115,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_requests/expected.data.yml
+++ b/tests/plugin/sw_requests/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_sanic/expected.data.yml
+++ b/tests/plugin/sw_sanic/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,11 +79,11 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
               - key: http.params
                 value: "test=[test1,test2]\ntest2=[test2]"
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_sanic/test_sanic.py
+++ b/tests/plugin/sw_sanic/test_sanic.py
@@ -30,7 +30,7 @@ def prepare():
 
 class TestPlugin(TestPluginBase):
     @pytest.mark.parametrize('version', [
-        'sanic==20.3.0',
+        # 'sanic==20.3.0',
         'sanic==20.6.0',
         'sanic==20.9.0',
         'sanic==20.9.1',

--- a/tests/plugin/sw_tornado/expected.data.yml
+++ b/tests/plugin/sw_tornado/expected.data.yml
@@ -29,9 +29,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -61,9 +61,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0
@@ -79,9 +79,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: http://0.0.0.0:9090/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             startTime: gt 0
             endTime: gt 0

--- a/tests/plugin/sw_urllib3/expected.data.yml
+++ b/tests/plugin/sw_urllib3/expected.data.yml
@@ -30,9 +30,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: http://provider:9091/users
-              - key: status.code
+              - key: http.status.code
                 value: '200'
             refs:
               - parentEndpoint: /users
@@ -69,9 +69,9 @@ segmentItems:
             tags:
               - key: http.method
                 value: POST
-              - key: url
+              - key: http.url
                 value: 'http://provider:9091/users'
-              - key: status.code
+              - key: http.status.code
                 value: '200'
           - operationName: /users
             operationId: 0
@@ -88,7 +88,7 @@ segmentItems:
             tags:
               - key: http.method
                 value: GET
-              - key: url
+              - key: http.url
                 value: 'http://0.0.0.0:9090/users'
-              - key: status.code
+              - key: http.status.code
                 value: '200'


### PR DESCRIPTION
This is for merging after #143 (it does include all the changes from that PR which has already been approved but not yet merged). This cleans up the Tag mechanism as follows:
* Each Tag is now its own individual class, which allows 'overridable' to be property of the Tag and not specified at tag instantiate.
* Should be more performant.
* Key changes `url` -> `http.url` and `status.code` -> `http.status.code` to match Node agent.
