### PR TITLE
Enable HTTP log reporting

### DIFF
--- a/docs/LogReporter.md
+++ b/docs/LogReporter.md
@@ -1,4 +1,4 @@
-# Python agent gRPC log reporter
+# Python agent log reporter
 
 This functionality reports logs collected from the Python logging module(in theory, also logging libraries depending on the core logging module).
 
@@ -12,6 +12,8 @@ config.init(collector_address='127.0.0.1:11800', service_name='your awesome serv
                 log_reporter_active=True)
 agent.start()
 ``` 
+
+Note, if chosen `HTTP` protocol instead of `gRPC`/`Kafka`, the logs will be batch-reported to the collector REST endpoint.
 
 `log_reporter_active=True` - Enables the log reporter.
 

--- a/skywalking/client/http.py
+++ b/skywalking/client/http.py
@@ -123,7 +123,7 @@ class HttpLogDataReportService(TraceSegmentReportService):
         self.session = requests.Session()
 
     def report(self, generator):
-        for log_data in generator:
-            json_string = json_format.MessageToJson(log_data)
-            res = self.session.post(self.url_report, json=[json.loads(json_string)])
-            logger.debug('report log response: %s', res)
+        log_batch = [json.loads(json_format.MessageToJson(log_data)) for log_data in generator]
+        if log_batch:  # prevent empty batches
+            res = self.session.post(self.url_report, json=log_batch)
+            logger.debug('report batch log response: %s', res)

--- a/skywalking/client/http.py
+++ b/skywalking/client/http.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from skywalking.loggings import logger
+import json
 
 import requests
+from google.protobuf import json_format
 
 from skywalking import config
 from skywalking.client import ServiceManagementClient, TraceSegmentReportService
+from skywalking.loggings import logger
 
 
 class HttpServiceManagementClient(ServiceManagementClient):
@@ -109,3 +110,20 @@ class HttpTraceSegmentReportService(TraceSegmentReportService):
                 } for span in segment.spans]
             })
             logger.debug('report traces response: %s', res)
+
+
+class HttpLogDataReportService(TraceSegmentReportService):
+    def __init__(self):
+        proto = 'https://' if config.force_tls else 'http://'
+        self.url_report = proto + config.collector_address.rstrip('/') + '/v3/logs'
+        self.session = requests.Session()
+
+    def fork_after_in_child(self):
+        self.session.close()
+        self.session = requests.Session()
+
+    def report(self, generator):
+        for log_data in generator:
+            json_string = json_format.MessageToJson(log_data)
+            res = self.session.post(self.url_report, json=[json.loads(json_string)])
+            logger.debug('report log response: %s', res)


### PR DESCRIPTION
This is a work in progress. 

Now reporting logs in JSON through HTTP to `http://oap/v3/logs` does work. 

But, I'm not sure if the `oap/v3/logs` endpoint is for such usage(It seems designed for fluent-bit batch reporting?). Reporting logs one by one through HTTP may not be ideal in terms of performance. I'm not sure whether the Java agent only implements gRPC reporter intentionally out of this reason. 

Please advise.

  
Signed-off-by: YihaoChen <Superskyyy@outlook.com>
