### PR TITLE
[plugin] pymongo compatible with mongodb cluster

### DIFF
--- a/skywalking/plugins/sw_pymongo.py
+++ b/skywalking/plugins/sw_pymongo.py
@@ -101,8 +101,8 @@ def inject_bulk_write(_Bulk, bulk_op_map):
     _execute = _Bulk.execute
 
     def _sw_execute(this: _Bulk, *args, **kwargs):
-        address = this.collection.database.client.address
-        peer = "%s:%s" % address
+        nodes = this.collection.database.client.nodes
+        peer = ",".join(["%s:%s" % address for address in nodes])
         context = get_context()
 
         sw_op = "MixedBulkWriteOperation"
@@ -134,8 +134,8 @@ def inject_cursor(Cursor):
     __send_message = Cursor._Cursor__send_message
 
     def _sw_send_message(this: Cursor, operation):
-        address = this.collection.database.client.address
-        peer = "%s:%s" % address
+        nodes = this.collection.database.client.nodes
+        peer = ",".join(["%s:%s" % address for address in nodes])
 
         context = get_context()
         op = "FindOperation"


### PR DESCRIPTION
replace the `this.collection.database.client.address` with the `this.collection.database.client.nodes` to be compatible with the mongodb cluster

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
