### PR TITLE
Fixes and tweaks to recent falcon plugin

### DIFF
--- a/skywalking/plugins/sw_falcon.py
+++ b/skywalking/plugins/sw_falcon.py
@@ -15,84 +15,65 @@
 # limitations under the License.
 #
 
-from skywalking import Layer, Component
+from skywalking import Layer, Component, config
 from skywalking.trace.carrier import Carrier
-from skywalking.trace.context import get_context
+from skywalking.trace.context import get_context, NoopContext
 from skywalking.trace.span import NoopSpan
-from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpParams, TagHttpStatusCode
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpParams, TagHttpStatusCode, TagHttpStatusMsg
 
 
 def install():
-    from falcon import API, request, response
+    from falcon import API, request, RequestOptions
 
     _original_falcon_api = API.__call__
-    _original_falcon_handle_exception = API._handle_exception
-
-    def params_tostring(params):
-        return "\n".join([k + "=" + v for k, v in params.items()])
 
     def _sw_falcon_api(this: API, env, start_response):
         context = get_context()
         carrier = Carrier()
-        headers = get_headers(env)
+        req = request.Request(env, RequestOptions())
+        headers = req.headers
+        method = req.method
+
         for item in carrier:
-            key = item.key.replace("_", "-") if "_" in item.key else item.key
-            if key.capitalize() in headers:
-                item.val = headers[key.capitalize()]
-        with context.new_entry_span(op="/", carrier=carrier) as span:
+            key = item.key.upper()
+            if key in headers:
+                item.val = headers[key]
+
+        span = NoopSpan(NoopContext()) if config.ignore_http_method_check(method) \
+            else context.new_entry_span(op=req.path, carrier=carrier)
+
+        with span:
             span.layer = Layer.Http
             span.component = Component.Falcon
+            span.peer = req.remote_addr
 
-            from falcon import RequestOptions
-
-            req = request.Request(env, RequestOptions())
-            span.op = str(req.url).split("?")[0]
-            span.peer = "%s:%s" % (req.remote_addr, req.port)
-
-            span.tag(TagHttpMethod(req.method))
+            span.tag(TagHttpMethod(method))
             span.tag(TagHttpURL(str(req.url)))
+
             if req.params:
-                span.tag(TagHttpParams(params_tostring(req.params)[0:]))
+                span.tag(TagHttpParams(','.join([k + '=' + v for k, v in req.params.items()])))
 
-            resp = _original_falcon_api(this, env, start_response)
+            def _start_response(resp_status, headers):
+                try:
+                    code, msg = resp_status.split(' ', 1)
+                    code = int(code)
+                except Exception:
+                    code, msg = 500, 'Internal Server Error'
 
-            from falcon import ResponseOptions
+                if code >= 400:
+                    span.error_occurred = True
 
-            resp_obj = response.Response(ResponseOptions())
+                span.tag(TagHttpStatusCode(code))
+                span.tag(TagHttpStatusMsg(msg))
 
-            resp_status = parse_status(resp_obj.status)
-            if int(resp_status[0]) >= 400:
-                span.error_occurred = True
+                return start_response(resp_status, headers)
 
-            span.tag(TagHttpStatusCode(int(resp_status[0])))
+            try:
+                return _original_falcon_api(this, env, _start_response)
 
-            return resp
+            except Exception:
+                span.raised()
 
-    def _sw_handle_exception(this: API, req, resp, ex, params):
-        if ex is not None:
-            entry_span = get_context().active_span()
-            if entry_span is not None and type(entry_span) is not NoopSpan:
-                entry_span.raised()
-
-        return _original_falcon_handle_exception(this, req, resp, ex, params)
+                raise
 
     API.__call__ = _sw_falcon_api
-    API._handle_exception = _sw_handle_exception
-
-
-def get_headers(env):
-    headers = {}
-    wsgi_content_headers = frozenset(["CONTENT_TYPE", "CONTENT_LENGTH"])
-
-    for name, value in env.items():
-        if name.startswith("HTTP_"):
-            headers[name[5:].replace("_", "-")] = value
-
-        elif name in wsgi_content_headers:
-            headers[name.replace("_", "-")] = value
-
-    return headers
-
-
-def parse_status(status_str):
-    return status_str.split(" ") if status_str else [404, "status is empty"]

--- a/skywalking/trace/tags.py
+++ b/skywalking/trace/tags.py
@@ -34,6 +34,10 @@ class TagHttpStatusCode(Tag):
     key = 'http.status.code'
 
 
+class TagHttpStatusMsg(Tag):
+    key = 'http.status.msg'
+
+
 class TagHttpParams(Tag):
     key = 'http.params'
 

--- a/tests/plugin/sw_falcon/expected.data.yml
+++ b/tests/plugin/sw_falcon/expected.data.yml
@@ -23,7 +23,7 @@ segmentItems:
       endTime: gt 0
       isError: false
       operationId: 0
-      operationName: http://provider:9091/users
+      operationName: /users
       parentSpanId: -1
       peer: not null
       skipAnalysis: false
@@ -38,6 +38,8 @@ segmentItems:
         value: http://provider:9091/users
       - key: http.status.code
         value: '200'
+      - key: http.status.msg
+        value: OK
   serviceName: provider
 - segmentSize: 1
   segments:
@@ -66,7 +68,7 @@ segmentItems:
       endTime: gt 0
       isError: false
       operationId: 0
-      operationName: http://0.0.0.0:9090/users
+      operationName: /users
       parentSpanId: -1
       peer: not null
       skipAnalysis: false
@@ -81,4 +83,6 @@ segmentItems:
         value: http://0.0.0.0:9090/users
       - key: http.status.code
         value: '200'
+      - key: http.status.msg
+        value: OK
   serviceName: consumer


### PR DESCRIPTION
Some tweaks to #146

* Operation endpoint name gotten from url path instead of being whole URL.
* Added ignore by http method.
* Port of peer was incorrectly set from server port.
* Headers gotten directly from request object instead of parsing environment.
* Order of parameters in _handle_exception was wrong.
* HTTP parameters joined by comma instead of newline.
* The line "resp_obj = response.Response(ResponseOptions())" was just creating a new clean response without taking into account any errors from the current request, so errors like 404 were not marked as errors and returned with code 200.
* Replaced _sw_handle_exception with a direct wrap of call to handler just in case registered exception handlers suppress the exception.
* Added TagHttpStatusMsg.
