### PR TITLE
exponential reconnection backoff

### DIFF
--- a/skywalking/agent/protocol/kafka.py
+++ b/skywalking/agent/protocol/kafka.py
@@ -45,14 +45,20 @@ class KafkaProtocol(Protocol):
         self.service_management.send_heart_beat()
 
     def report(self, queue: Queue, block: bool = True):
-        start = time()
+        start = None
 
         def generator():
+            nonlocal start
+
             while True:
                 try:
-                    timeout = config.QUEUE_TIMEOUT - int(time() - start)  # type: int
-                    if timeout <= 0:  # this is to make sure we exit eventually instead of being fed continuously
-                        return
+                    timeout = config.QUEUE_TIMEOUT  # type: int
+                    if not start:  # make sure first time through queue is always checked
+                        start = time()
+                    else:
+                        timeout -= int(time() - start)
+                        if timeout <= 0:  # this is to make sure we exit eventually instead of being fed continuously
+                            return
                     segment = queue.get(block=block, timeout=timeout)  # type: Segment
                 except Empty:
                     return
@@ -103,14 +109,20 @@ class KafkaProtocol(Protocol):
         self.traces_reporter.report(generator())
 
     def report_log(self, queue: Queue, block: bool = True):
-        start = time()
+        start = None
 
         def generator():
+            nonlocal start
+
             while True:
                 try:
-                    timeout = config.QUEUE_TIMEOUT - int(time() - start)  # type: int
-                    if timeout <= 0:
-                        return
+                    timeout = config.QUEUE_TIMEOUT  # type: int
+                    if not start:  # make sure first time through queue is always checked
+                        start = time()
+                    else:
+                        timeout -= int(time() - start)
+                        if timeout <= 0:  # this is to make sure we exit eventually instead of being fed continuously
+                            return
                     log_data = queue.get(block=block, timeout=timeout)  # type: LogData
                 except Empty:
                     return

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -74,7 +74,6 @@ profile_duration = int(os.getenv('SW_AGENT_PROFILE_DURATION') or '10')  # type: 
 profile_dump_max_stack_depth = int(os.getenv('SW_AGENT_PROFILE_DUMP_MAX_STACK_DEPTH') or '500')  # type: int
 profile_snapshot_transport_buffer_size = int(os.getenv('SW_AGENT_PROFILE_SNAPSHOT_TRANSPORT_BUFFER_SIZE') or '50')
 
-# NOTE - Log reporting requires a separate channel, will merge in the future.
 log_reporter_active = True if os.getenv('SW_AGENT_LOG_REPORTER_ACTIVE') and \
                               os.getenv('SW_AGENT_LOG_REPORTER_ACTIVE') == 'True' else False  # type: bool
 log_reporter_max_buffer_size = int(os.getenv('SW_AGENT_LOG_REPORTER_BUFFER_SIZE') or '10000')  # type: int


### PR DESCRIPTION
Added generic hackish incrementing reconnect timeout on consecutive errors to avoid constant reconnect attempts from grpc if OAP server is down as mentioned in #138. This is a little ugly because each thread has its own timeout so all threads will attempt to reconnect individually after the timeout (no concept of a common connection), but is not so bad with current maximum timeout of 1 min to have a few threads try to reconnect for now.

Also this will handle any other unexpected exception which may happen during send for any reason, will prevent them from erroring constantly and eating 100% cpu and will enforce a delay between attempts if there is some problem.

Also changed how timeout start is handled in report generator functions. Previously there was a very small but non-zero chance that if for some reason it took longer than 1 second to get from:
```py
start = time()
```
to:
```py
timeout = config.QUEUE_TIMEOUT - int(time() - start)
```
in the first pass through the loop then a send may not have been attempted at all. Now it will always send the first time through the loop.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
