### PR TITLE
spans correctly reference finished parents

### DIFF
--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -123,6 +123,15 @@ class Span(ABC):
 
         self.context.segment.relate(ID(carrier.trace_id))
         self.context._correlation = carrier.correlation_carrier.correlation
+
+        if not carrier.is_valid:
+            return self
+
+        ref = SegmentRef(carrier=carrier)
+
+        if ref not in self.refs:
+            self.refs.append(ref)
+
         return self
 
     def __enter__(self):
@@ -170,19 +179,6 @@ class EntrySpan(Span):
         self.layer = Layer.Unknown
         self.logs = []
         self.tags = defaultdict(list)
-
-    def extract(self, carrier: 'Carrier') -> 'Span':
-        Span.extract(self, carrier)
-
-        if carrier is None or not carrier.is_valid:
-            return self
-
-        ref = SegmentRef(carrier=carrier)
-
-        if ref not in self.refs:
-            self.refs.append(ref)
-
-        return self
 
 
 @tostring


### PR DESCRIPTION
Spans will now correctly create a new context and reference a parent when that parent context had already finished and the segment was archived. For example, previously, the tornado handler below did not correctly record the `requests.get()` because it executed after the parent task had already finished. Now it does:
```py
import asyncio
import requests

import tornado.ioloop
import tornado.web

from skywalking import agent; agent.start()

class Dead(tornado.web.RequestHandler):
    async def out(self):
        await asyncio.sleep(1)
        requests.get('http://www.google.com/')

    async def get(self):
        asyncio.create_task(self.out())
        self.write('Hello from dead link')

def make_app():
    return tornado.web.Application([
        (r"/dead", Dead),
    ])

if __name__ == "__main__":
    app = make_app()
    app.listen(8002)
    tornado.ioloop.IOLoop.current().start()
```
