### PR TITLE
Remove places that mentions Python 3.5 support due to EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ microservices, cloud native and container-based (Docker, Kubernetes, Mesos) arch
 
 ## Installation Requirements
 
-SkyWalking Python Agent requires SkyWalking 8.0+ and Python 3.5+.
+SkyWalking Python Agent requires SkyWalking 8.0+ and Python 3.6+.
 
 > If you would like to try out the latest features that are not released yet, please refer to this [guide](docs/en/setup/faq/How-to-build-from-sources.md) to build from sources.
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,9 +18,8 @@ D := docker
 
 P := grpc http kafka
 
-TARGETS := py3.5 py3.6 py3.7 py3.8 py3.9
+TARGETS := py3.6 py3.7 py3.8 py3.9
 
-py3.5: BASE_IMAGE = python:3.5
 py3.6: BASE_IMAGE = python:3.6
 py3.7: BASE_IMAGE = python:3.7
 py3.8: BASE_IMAGE = python:3.8

--- a/docs/en/setup/Container.md
+++ b/docs/en/setup/Container.md
@@ -4,7 +4,7 @@
 source**
 
 This image hosts the SkyWalking Python agent package on top of official Python base images providing support from 
-Python 3.5 - 3.9.
+Python 3.6 - 3.9.
 
 ## How to use this image
 

--- a/docs/en/setup/Installation.md
+++ b/docs/en/setup/Installation.md
@@ -1,6 +1,6 @@
 ## Installation
 
-**SkyWalking Python agent requires SkyWalking 8.0+ and Python 3.5+**
+**SkyWalking Python agent requires SkyWalking 8.0+ and Python 3.6+**
 
 You can install the SkyWalking Python agent via various ways.
 

--- a/docs/en/setup/Plugins.md
+++ b/docs/en/setup/Plugins.md
@@ -2,8 +2,8 @@
 
 Library | Versions | Plugin Name
 | :--- | :--- | :--- |
-| [http.server](https://docs.python.org/3/library/http.server.html) | Python 3.5 ~ 3.9 | `sw_http_server` |
-| [urllib.request](https://docs.python.org/3/library/urllib.request.html) | Python 3.5 ~ 3.9 | `sw_urllib_request` |
+| [http.server](https://docs.python.org/3/library/http.server.html) | Python 3.6 ~ 3.9 | `sw_http_server` |
+| [urllib.request](https://docs.python.org/3/library/urllib.request.html) | Python 3.6 ~ 3.9 | `sw_urllib_request` |
 | [requests](https://requests.readthedocs.io/en/master/) | >= 2.9.0 < 2.15.0, >= 2.17.0 <= 2.24.0 | `sw_requests` |
 | [Flask](https://flask.palletsprojects.com/en/1.1.x/) | >=1.0.4 <= 1.1.2 | `sw_flask` |
 | [PyMySQL](https://pymysql.readthedocs.io/en/latest/) | 0.10.0 | `sw_pymysql` |

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
 
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Will test Python 3.10 when officially releases next month.

Signed-off-by: Superskyyy <Superskyyy@outlook.com>

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
