### PR TITLE
filled out rest of psycopg 3 plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ gen:
 
 lint: clean
 	flake8 --version || python3 -m pip install flake8
-	flake8 . --count --show-source
+	flake8 . --count --show-source --max-complexity 20
 
 dev-check:
 	flake8 --version || python3 -m pip install flake8
-	flake8 . --count --show-source
+	flake8 . --count --show-source --max-complexity 20
 	python3 tools/check-license-header.py skywalking tests tools
 
 license: clean

--- a/skywalking/plugins/sw_psycopg.py
+++ b/skywalking/plugins/sw_psycopg.py
@@ -28,7 +28,7 @@ support_matrix = {
 note = """"""
 
 
-def install():
+def install_sync():
     import wrapt  # psycopg is read-only C extension objects so they need to be proxied
     import psycopg
 
@@ -141,7 +141,10 @@ def install():
     psycopg.Connection.connect = connect
     psycopg.connect = connect
 
-    # asynchronous
+
+def install_async():
+    import wrapt  # psycopg is read-only C extension objects so they need to be proxied
+    import psycopg
 
     class ProxyAsyncCursor(wrapt.ObjectProxy):
         def __init__(self, cur):
@@ -255,3 +258,8 @@ def install():
 
     _aconnect = psycopg.AsyncConnection.connect
     psycopg.AsyncConnection.connect = aconnect
+
+
+def install():
+    install_sync()
+    install_async()


### PR DESCRIPTION
A copy of psycopg2 to psycopg 3 was not enough since some interface stuff changed, this PR adds those changes:
* Removed Cursor.callproc()
* Added Cursor.stream()
* Hook Connection.connect()
* Instrumented AsyncConnection and AsyncCursor (which is the main point of psycopg 3 I think :)
* Still needs a test, will add simple script to convert to test if anyone is up for it, @Superskyyy ?