### PR TITLE
updated deprecated configuration

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -16,4 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ignore = [ "Unused ignore", "Invalid decoration", "blacklist", "Missing argument" ]
+ignoreRules = [ "Unused ignore", "Invalid decoration", "blacklist", "Missing argument" ]


### PR DESCRIPTION
The lift configuration has now deprecated `ignore` in favour of `ignoreRules`, this change moves to that new configuration. see documentation for reference: https://help.sonatype.com/lift/configuration-reference#ConfigurationReference-in-repo-optionsIn-RepoOptions(The.lift.toml)

Previous analysis were actually failing: https://lift.sonatype.com/results/github.com/apache/skywalking-python/01FTDGMNAGFME81YY6VKZ3R343?tab=logs

