### PR TITLE
Fix sw-rabbitmq TypeError when there are no headers

### DIFF
--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -80,8 +80,11 @@ def _sw__on_deliver_func(__on_deliver):
         routing_key = method_frame.method.routing_key
         carrier = Carrier()
         for item in carrier:
-            if item.key in header_frame.properties.headers:
-                item.val = header_frame.properties.headers[item.key]
+            try:
+                if item.key in header_frame.properties.headers:
+                    item.val = header_frame.properties.headers[item.key]
+            except TypeError as te:
+                pass
 
         with context.new_entry_span(op='RabbitMQ/Topic/' + exchange + '/Queue/' + routing_key
                                        + '/Consumer' or '', carrier=carrier) as span:

--- a/skywalking/plugins/sw_rabbitmq.py
+++ b/skywalking/plugins/sw_rabbitmq.py
@@ -83,7 +83,7 @@ def _sw__on_deliver_func(__on_deliver):
             try:
                 if item.key in header_frame.properties.headers:
                     item.val = header_frame.properties.headers[item.key]
-            except TypeError as te:
+            except TypeError:
                 pass
 
         with context.new_entry_span(op='RabbitMQ/Topic/' + exchange + '/Queue/' + routing_key


### PR DESCRIPTION
Add a try/except on TypeError
to catch None headers
when messages in the queue were produced pre-skywalking & without header

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->

Fix [#8499](https://github.com/apache/skywalking/issues/8499)
