### PR TITLE
Fix agent bootup traceback not shown in sw-python CLI

### DIFF
--- a/skywalking/bootstrap/cli/sw_python.py
+++ b/skywalking/bootstrap/cli/sw_python.py
@@ -62,7 +62,7 @@ def start() -> None:
         dispatch(args)
     except SWRunnerFailure:
         cli_logger.exception(f"Failed to run the given user application command `{' '.join(args.command)}`, "
-                         f'please make sure given command is valid.')
+                             f'please make sure given command is valid.')
         return
 
 

--- a/skywalking/bootstrap/cli/sw_python.py
+++ b/skywalking/bootstrap/cli/sw_python.py
@@ -61,7 +61,7 @@ def start() -> None:
     try:
         dispatch(args)
     except SWRunnerFailure:
-        cli_logger.error(f"Failed to run the given user application command `{' '.join(args.command)}`, "
+        cli_logger.exception(f"Failed to run the given user application command `{' '.join(args.command)}`, "
                          f'please make sure given command is valid.')
         return
 

--- a/skywalking/bootstrap/loader/sitecustomize.py
+++ b/skywalking/bootstrap/loader/sitecustomize.py
@@ -146,4 +146,4 @@ else:
         _sw_loader_logger.debug('SkyWalking Python Agent starting, loader finished.')
         agent.start()
     except Exception:
-        _sw_loader_logger.error('SkyWalking Python Agent failed to start, please inspect your package installation')
+        _sw_loader_logger.exception('SkyWalking Python Agent failed to start, please inspect your package installation')


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
Minor change to improve debugging experience. https://github.com/apache/skywalking/discussions/8518
