### PR TITLE
Support CI container logs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Plugin and Unit Tests
     needs: prep-plugin-and-unit-tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]

--- a/skywalking/plugins/__init__.py
+++ b/skywalking/plugins/__init__.py
@@ -59,7 +59,11 @@ def install():
             plugin.install()
             logger.debug('Successfully installed plugin %s', modname)
         except Exception:
-            logger.warning('failed to install plugin %s', modname)
+            logger.warning(
+                'plugin %s failed to install, please disregard this warning '
+                'if the corresponding package was not used in your project',
+                modname
+            )
             traceback.print_exc() if logger.isEnabledFor(logging.DEBUG) else None
 
 

--- a/tests/plugin/data/sw_elasticsearch/test_elasticsearch.py
+++ b/tests/plugin/data/sw_elasticsearch/test_elasticsearch.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_kafka/test_kafka.py
+++ b/tests/plugin/data/sw_kafka/test_kafka.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_mysqlclient/services/consumer.py
+++ b/tests/plugin/data/sw_mysqlclient/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_mysqlclient/test_mysqlclient.py
+++ b/tests/plugin/data/sw_mysqlclient/test_mysqlclient.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_psycopg/services/consumer.py
+++ b/tests/plugin/data/sw_psycopg/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_psycopg/test_psycopg.py
+++ b/tests/plugin/data/sw_psycopg/test_psycopg.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_psycopg2/services/consumer.py
+++ b/tests/plugin/data/sw_psycopg2/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_psycopg2/test_psycopg2.py
+++ b/tests/plugin/data/sw_psycopg2/test_psycopg2.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_pymongo/services/consumer.py
+++ b/tests/plugin/data/sw_pymongo/services/consumer.py
@@ -25,9 +25,9 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        requests.get('http://provider:9091/insert_many')
-        requests.get('http://provider:9091/find_one')
-        res = requests.get('http://provider:9091/delete_one')
+        requests.get('http://provider:9091/insert_many', timeout=5)
+        requests.get('http://provider:9091/find_one', timeout=5)
+        res = requests.get('http://provider:9091/delete_one', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_pymongo/test_pymongo.py
+++ b/tests/plugin/data/sw_pymongo/test_pymongo.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_pymysql/services/consumer.py
+++ b/tests/plugin/data/sw_pymysql/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_pymysql/test_pymysql.py
+++ b/tests/plugin/data/sw_pymysql/test_pymysql.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_rabbitmq/test_rabbitmq.py
+++ b/tests/plugin/data/sw_rabbitmq/test_rabbitmq.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/data/sw_redis/services/consumer.py
+++ b/tests/plugin/data/sw_redis/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['POST', 'GET'])
     def application():
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
         return jsonify(res.json())
 
     PORT = 9090

--- a/tests/plugin/data/sw_redis/test_redis.py
+++ b/tests/plugin/data/sw_redis/test_redis.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/docker-compose.base.yml
+++ b/tests/plugin/docker-compose.base.yml
@@ -19,7 +19,7 @@ version: '2.1'
 
 services:
   collector:
-    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:5acb890f225ca37ee60675ce3e330545e23e3cbc
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:092c6a3c753684b5a301baf5bcb1965f2dfaf79d
     ports:
       - 19876:19876
       - 12800:12800
@@ -40,6 +40,8 @@ services:
     environment:
       SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector:19876
       SW_AGENT_LOGGING_LEVEL: DEBUG
+      # Agent test tool does not support profiling, TODO: address in e2e ref: #155
+      SW_AGENT_PROFILE_ACTIVE: 'False'
     networks:
       - beyond
     command: ['python3', '/entrypoint.py']

--- a/tests/plugin/http/sw_aiohttp/test_aiohttp.py
+++ b/tests/plugin/http/sw_aiohttp/test_aiohttp.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture  # pyre-ignore
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/skywalking')
+    return lambda *_: requests.get('http://0.0.0.0:9090/skywalking', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/http/sw_http/test_http.py
+++ b/tests/plugin/http/sw_http/test_http.py
@@ -25,7 +25,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.post('http://0.0.0.0:9090')
+    return lambda *_: requests.post('http://0.0.0.0:9090', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/http/sw_http_wsgi/test_http_wsgi.py
+++ b/tests/plugin/http/sw_http_wsgi/test_http_wsgi.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.post('http://0.0.0.0:9090')
+    return lambda *_: requests.post('http://0.0.0.0:9090', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/http/sw_requests/services/consumer.py
+++ b/tests/plugin/http/sw_requests/services/consumer.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
             self.send_header('Content-Type', 'application/json; charset=utf-8')
             self.end_headers()
 
-            res = requests.post('http://provider:9091/users')
+            res = requests.post('http://provider:9091/users', timeout=5)
             self.wfile.write(str(res.json()).encode('utf8'))
 
     PORT = 9090

--- a/tests/plugin/http/sw_requests/test_request.py
+++ b/tests/plugin/http/sw_requests/test_request.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.post('http://0.0.0.0:9090')
+    return lambda *_: requests.post('http://0.0.0.0:9090', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/http/sw_urllib3/test_urllib3.py
+++ b/tests/plugin/http/sw_urllib3/test_urllib3.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_django/services/consumer.py
+++ b/tests/plugin/web/sw_django/services/consumer.py
@@ -30,7 +30,7 @@ settings.configure(
 
 
 def index(request):
-    res = requests.post('http://provider:9091/users')
+    res = requests.post('http://provider:9091/users', timeout=5)
     return JsonResponse(res.json())
 
 

--- a/tests/plugin/web/sw_django/test_django.py
+++ b/tests/plugin/web/sw_django/test_django.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_falcon/services/consumer.py
+++ b/tests/plugin/web/sw_falcon/services/consumer.py
@@ -20,7 +20,7 @@ import requests
 
 @hug.get('/users')
 def get():
-    res = requests.get('http://provider:9091/users')
+    res = requests.get('http://provider:9091/users', timeout=5)
     return res.json()
 
 

--- a/tests/plugin/web/sw_falcon/test_falcon.py
+++ b/tests/plugin/web/sw_falcon/test_falcon.py
@@ -28,7 +28,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_fastapi/services/consumer.py
+++ b/tests/plugin/web/sw_fastapi/services/consumer.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     @app.get('/users')
     async def application():
-        res = requests.get('http://provider:9091/users')
+        res = requests.get('http://provider:9091/users', timeout=5)
         return res.json()
 
     uvicorn.run(app, host='0.0.0.0', port=9090)

--- a/tests/plugin/web/sw_fastapi/test_fastapi.py
+++ b/tests/plugin/web/sw_fastapi/test_fastapi.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_flask/services/consumer.py
+++ b/tests/plugin/web/sw_flask/services/consumer.py
@@ -31,13 +31,13 @@ if __name__ == '__main__':
 
         @runnable(op='/test')
         def post():
-            requests.post('http://provider:9091/users')
+            requests.post('http://provider:9091/users', timeout=5)
 
         from threading import Thread
         t = Thread(target=post)
         t.start()
 
-        res = requests.post('http://provider:9091/users')
+        res = requests.post('http://provider:9091/users', timeout=5)
 
         t.join()
 

--- a/tests/plugin/web/sw_flask/test_flask.py
+++ b/tests/plugin/web/sw_flask/test_flask.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2', timeout=5)
 
 
 class TestPlugin(TestPluginBase):
@@ -35,6 +35,6 @@ class TestPlugin(TestPluginBase):
     def test_plugin(self, docker_compose, version):
         self.validate()
 
-        response = requests.get('http://0.0.0.0:9090/users')
+        response = requests.get('http://0.0.0.0:9090/users', timeout=5)
         assert response.status_code == 200
         assert response.json()['correlation'] == 'correlation'

--- a/tests/plugin/web/sw_pyramid/test_pyramid.py
+++ b/tests/plugin/web/sw_pyramid/test_pyramid.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/pyramid')
+    return lambda *_: requests.get('http://0.0.0.0:9090/pyramid', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_sanic/services/consumer.py
+++ b/tests/plugin/web/sw_sanic/services/consumer.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
 
     @app.route('/users', methods=['GET'])
     async def application(req):
-        res = requests.get('http://provider:9091/users')
+        res = requests.get('http://provider:9091/users', timeout=5)
         return response.json(res.json())
 
     PORT = 9090

--- a/tests/plugin/web/sw_sanic/test_sanic.py
+++ b/tests/plugin/web/sw_sanic/test_sanic.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users?test=test1&test=test2&test2=test2', timeout=5)
 
 
 class TestPlugin(TestPluginBase):

--- a/tests/plugin/web/sw_tornado/services/consumer.py
+++ b/tests/plugin/web/sw_tornado/services/consumer.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
 
     class MainHandler(tornado.web.RequestHandler):
         def get(self):
-            res = requests.get('http://provider:9091/users')
+            res = requests.get('http://provider:9091/users', timeout=5)
             self.write(res.text)
 
     def make_app():

--- a/tests/plugin/web/sw_tornado/test_tornado.py
+++ b/tests/plugin/web/sw_tornado/test_tornado.py
@@ -27,7 +27,7 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users')
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
 
 
 class TestPlugin(TestPluginBase):


### PR DESCRIPTION
- Supports testcontainer logs from GitHub actions, so no mysterious failures again. 
![image](https://user-images.githubusercontent.com/26076517/154581476-429711a2-3c5a-4a28-b1c0-378be9363dab.png)

- Also added timeouts to all calls to requests.get/post so that a bad testcase wouldn't hang the entire CI till timeout.
 
- Disabled profiling reporter in test suite since the agent test tool doesn't support the data and keeps throwing irrelevant exceptions.

- Bumped up data protocol dependency to latest master.