### PR TITLE
Fix: right doc link for How To Use With uWSGI

### DIFF
--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -47,7 +47,7 @@ catalog:
       - name: "How To Build from Sources"
         path: "/en/setup/faq/How-to-build-from-sources"
       - name: "How To Use With uWSGI"
-        path: "/en/setup/faq/How-to-use-with-uwsgi.md"
+        path: "/en/setup/faq/How-to-use-with-uwsgi"
   - name: "Contribution"
     catalog:
       - name: "Developer Guidance"


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->

now the doc link is error : https://skywalking.apache.org/docs/skywalking-python/latest/en/setup/faq/how-to-use-with-uwsgi.md 

right link should be: https://skywalking.apache.org/docs/skywalking-python/latest/en/setup/faq/how-to-use-with-uwsgi/