### PR TITLE
The local log stack depth is not truncated

### DIFF
--- a/skywalking/log/sw_logging.py
+++ b/skywalking/log/sw_logging.py
@@ -69,6 +69,8 @@ def install():
 
         context = get_context()
 
+        _handle(self=self, record=record)
+
         log_data = LogData(
             timestamp=round(record.created * 1000),
             service=config.service_name,
@@ -86,7 +88,7 @@ def install():
             ),
             tags=build_log_tags(),
         )
-        _handle(self=self, record=record)
+
 
         agent.archive_log(log_data)
 


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
