### PR TITLE
Revert "The local log stack depth is not truncated (#190)"

### DIFF
--- a/skywalking/log/sw_logging.py
+++ b/skywalking/log/sw_logging.py
@@ -69,8 +69,6 @@ def install():
 
         context = get_context()
 
-        _handle(self=self, record=record)
-
         log_data = LogData(
             timestamp=round(record.created * 1000),
             service=config.service_name,
@@ -88,7 +86,7 @@ def install():
             ),
             tags=build_log_tags(),
         )
-
+        _handle(self=self, record=record)
 
         agent.archive_log(log_data)
 


### PR DESCRIPTION
This reverts commit cd559e7159b92b0d5b9d26cda1da0517a646a709.

Discussion of the reason is hosted > https://github.com/apache/skywalking/issues/8699#issuecomment-1072929993
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
