### PR TITLE
Fix sw_formatter wrongly set cache that impacts user handlers

### DIFF
--- a/docs/en/setup/Plugins.md
+++ b/docs/en/setup/Plugins.md
@@ -3,7 +3,7 @@ This document is **automatically** generated from the SkyWalking Python testing 
 
 The column of versions only indicates the set of library versions tested in a best-effort manner.
 
-If you find newer major versions that are missing from the following table, and it's not documented as a limitation, 
+If you find newer major versions that are missing from the following table, and it's not documented as a limitation,
 please PR to update the test matrix in the plugin.
 
 Versions marked as NOT SUPPORTED may be due to
@@ -14,14 +14,16 @@ or a limitation of SkyWalking auto-instrumentation (welcome to contribute!)
 Library | Python Version - Lib Version | Plugin Name
 | :--- | :--- | :--- |
 | [aiohttp](https://docs.aiohttp.org) | Python >=3.10 - NOT SUPPORTED YET; Python >=3.6 - ['3.7.4'];  | `sw_aiohttp` |
-| [celery](https://docs.celeryproject.org) | Python >=3.6 - ['5.1'];  | `sw_celery` |
+| [celery](https://docs.celeryq.dev) | Python >=3.6 - ['5.1'];  | `sw_celery` |
 | [django](https://www.djangoproject.com/) | Python >=3.6 - ['3.2'];  | `sw_django` |
 | [elasticsearch](https://github.com/elastic/elasticsearch-py) | Python >=3.6 - ['7.13', '7.14', '7.15'];  | `sw_elasticsearch` |
 | [hug](https://falcon.readthedocs.io/en/stable/) | Python >=3.10 - ['2.5', '2.6']; Python >=3.6 - ['2.4.1', '2.5', '2.6'];  | `sw_falcon` |
+| [fastapi](https://fastapi.tiangolo.com) | Python >=3.6 - ['0.70.1'];  | `sw_fastapi` |
 | [flask](https://flask.palletsprojects.com) | Python >=3.6 - ['1.1', '2.0'];  | `sw_flask` |
 | [http_server](https://docs.python.org/3/library/http.server.html) | Python >=3.6 - ['*'];  | `sw_http_server` |
 | [werkzeug](https://werkzeug.palletsprojects.com/) | Python >=3.6 - ['1.0.1', '2.0'];  | `sw_http_server` |
 | [kafka-python](https://kafka-python.readthedocs.io) | Python >=3.6 - ['2.0'];  | `sw_kafka` |
+| [mysqlclient](https://mysqlclient.readthedocs.io/) | Python >=3.6 - ['2.1.0'];  | `sw_mysqlclient` |
 | [psycopg[binary]](https://www.psycopg.org/) | Python >=3.6 - ['3.0'];  | `sw_psycopg` |
 | [psycopg2-binary](https://www.psycopg.org/) | Python >=3.10 - NOT SUPPORTED YET; Python >=3.6 - ['2.9'];  | `sw_psycopg2` |
 | [pymongo](https://pymongo.readthedocs.io) | Python >=3.6 - ['3.11'];  | `sw_pymongo` |
@@ -34,9 +36,7 @@ Library | Python Version - Lib Version | Plugin Name
 | [tornado](https://www.tornadoweb.org) | Python >=3.6 - ['6.0', '6.1'];  | `sw_tornado` |
 | [urllib3](https://urllib3.readthedocs.io/en/latest/) | Python >=3.6 - ['1.26', '1.25'];  | `sw_urllib3` |
 | [urllib_request](https://docs.python.org/3/library/urllib.request.html) | Python >=3.6 - ['*'];  | `sw_urllib_request` |
-| [mysqlclient](https://mysqlclient.readthedocs.io) | Python >=3.6 - ['2.1.0'];  | `sw_mysqlclient` |
-| [fastapi](https://fastapi.tiangolo.com) | Python >=3.6 - ['0.70.1'];  | `sw_fastapi` |
 ### Notes
 - The celery server running with "celery -A ..." should be run with the HTTP protocol
-as it uses multiprocessing by default which is not compatible with the gRPC protocol implementation 
+as it uses multiprocessing by default which is not compatible with the gRPC protocol implementation
 in SkyWalking currently. Celery clients can use whatever protocol they want.

--- a/skywalking/log/formatter.py
+++ b/skywalking/log/formatter.py
@@ -21,13 +21,17 @@ import traceback
 
 
 class SWFormatter(logging.Formatter):
-    """ A slightly modified formatter that allows traceback depth """
-
+    """
+    A slightly modified formatter that allows traceback depth
+    """
     def __init__(self, fmt, tb_limit):
         logging.Formatter.__init__(self, fmt)
         self.tb_limit = tb_limit
 
     def formatException(self, ei):  # noqa
+        """
+        Format and return the specified exception information as a string.
+        """
         sio = io.StringIO()
         tb = ei[2]
         traceback.print_exception(ei[0], ei[1], tb, self.tb_limit, sio)
@@ -36,3 +40,14 @@ class SWFormatter(logging.Formatter):
         if s[-1:] == '\n':
             s = s[:-1]
         return s
+
+    def format(self, record):
+        """
+        Bypass cache so we don't disturb other Formatters
+        """
+        _exc_text = record.exc_text
+        record.exc_text = None
+        result = super(SWFormatter, self).format(record)
+        record.exc_text = _exc_text
+
+        return result

--- a/skywalking/log/sw_logging.py
+++ b/skywalking/log/sw_logging.py
@@ -17,10 +17,9 @@
 
 import logging
 
+from skywalking import config, agent
 from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.logging.Logging_pb2 import LogData, LogDataBody, TraceContext, LogTags, TextLog
-
-from skywalking import config, agent
 from skywalking.trace.context import get_context
 from skywalking.utils.filter import sw_traceback, sw_filter
 
@@ -31,7 +30,7 @@ def install():
     layout = config.log_reporter_layout  # type: str
     if layout:
         from skywalking.log.formatter import SWFormatter
-        formatter = SWFormatter(fmt=layout, tb_limit=config.cause_exception_depth)
+        sw_formatter = SWFormatter(fmt=layout, tb_limit=config.cause_exception_depth)
 
     _handle = Logger.handle
     log_reporter_level = logging.getLevelName(config.log_reporter_level)  # type: int
@@ -89,7 +88,6 @@ def install():
             tags=build_log_tags(),
         )
 
-
         agent.archive_log(log_data)
 
     Logger.handle = _sw_handle
@@ -97,7 +95,7 @@ def install():
     def transform(record) -> str:
         if config.log_reporter_formatted:
             if layout:
-                return formatter.format(record=record)
+                return sw_formatter.format(record=record)
             newline = '\n'
             return f"{record.getMessage()}{f'{newline}{sw_traceback()}' if record.exc_info else ''}"
         return str(record.msg)  # convert possible exception to str

--- a/skywalking/plugins/sw_celery.py
+++ b/skywalking/plugins/sw_celery.py
@@ -20,7 +20,7 @@ from skywalking.trace.carrier import Carrier
 from skywalking.trace.context import get_context
 from skywalking.trace.tags import TagMqBroker, TagCeleryParameters
 
-link_vector = ['https://docs.celeryproject.org']
+link_vector = ['https://docs.celeryq.dev']
 # TODO: Celery is missing plugin test
 support_matrix = {
     'celery': {


### PR DESCRIPTION
1. preserve and restore the cached exc_text during the log interception process.
2. fix celery website so we don't get haunted by a potentially hijacked website and passes CI. 

closes https://github.com/apache/skywalking/issues/8699
merge after revert of https://github.com/apache/skywalking-python/pull/191
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
Signed-off-by: Superskyyy <superskyyy@outlook.com>