### PR TITLE
Drop support for Flask 1.x due to EOL & Jinja2 issue

### DIFF
--- a/docs/en/setup/Plugins.md
+++ b/docs/en/setup/Plugins.md
@@ -19,7 +19,7 @@ Library | Python Version - Lib Version | Plugin Name
 | [elasticsearch](https://github.com/elastic/elasticsearch-py) | Python >=3.6 - ['7.13', '7.14', '7.15'];  | `sw_elasticsearch` |
 | [hug](https://falcon.readthedocs.io/en/stable/) | Python >=3.10 - ['2.5', '2.6']; Python >=3.6 - ['2.4.1', '2.5', '2.6'];  | `sw_falcon` |
 | [fastapi](https://fastapi.tiangolo.com) | Python >=3.6 - ['0.70.1'];  | `sw_fastapi` |
-| [flask](https://flask.palletsprojects.com) | Python >=3.6 - ['1.1', '2.0'];  | `sw_flask` |
+| [flask](https://flask.palletsprojects.com) | Python >=3.6 - ['2.0'];  | `sw_flask` |
 | [http_server](https://docs.python.org/3/library/http.server.html) | Python >=3.6 - ['*'];  | `sw_http_server` |
 | [werkzeug](https://werkzeug.palletsprojects.com/) | Python >=3.6 - ['1.0.1', '2.0'];  | `sw_http_server` |
 | [kafka-python](https://kafka-python.readthedocs.io) | Python >=3.6 - ['2.0'];  | `sw_kafka` |

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -24,7 +24,7 @@ from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, 
 link_vector = ['https://flask.palletsprojects.com']
 support_matrix = {
     'flask': {
-        '>=3.6': ['1.1.4', '2.0.3']  # 1.1.4 is the last supported version, should be removed in near future
+        '>=3.6': ['2.0.3'] # 1.x removed due to EOL
     }
 }
 note = """"""

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -24,7 +24,7 @@ from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, 
 link_vector = ['https://flask.palletsprojects.com']
 support_matrix = {
     'flask': {
-        '>=3.6': ['2.0.3']  # 1.x removed due to EOL
+        '>=3.6': ['2.0']  # 1.x removed due to EOL
     }
 }
 note = """"""

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -24,7 +24,7 @@ from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, 
 link_vector = ['https://flask.palletsprojects.com']
 support_matrix = {
     'flask': {
-        '>=3.6': ['2.0.3'] # 1.x removed due to EOL
+        '>=3.6': ['2.0.3']  # 1.x removed due to EOL
     }
 }
 note = """"""

--- a/skywalking/plugins/sw_flask.py
+++ b/skywalking/plugins/sw_flask.py
@@ -24,7 +24,7 @@ from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode, 
 link_vector = ['https://flask.palletsprojects.com']
 support_matrix = {
     'flask': {
-        '>=3.6': ['1.1', '2.0']  # 1.1 to be removed in near future
+        '>=3.6': ['1.1.4', '2.0.3']  # 1.1.4 is the last supported version, should be removed in near future
     }
 }
 note = """"""


### PR DESCRIPTION
Flask 1.x is EOL and Jinja2 dependency now breaks UT, there's no need for us to maintain this version anymore.

Please merge this first.

Signed-off-by: Superskyyy <superskyyy@outlook.com><!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
-->
