### PR TITLE
Fix scheduled event fails changes CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,6 +50,8 @@ jobs:
     # set outputs for other jobs to access for if conditions
     runs-on: ubuntu-latest
     needs: license-and-lint
+    # To prevent error when there's no base branch
+    if: github.event_name != 'schedule'
     timeout-minutes: 10
     outputs:
       agent: ${{ steps.filter.outputs.agent }}
@@ -82,7 +84,7 @@ jobs:
     # prep step for plugin and unit test
     name: Prepare Plugin and UT Matrix
     needs: [ license-and-lint, changes ]
-    if: ${{ needs.changes.outputs.agent == 'true' }}
+    if: github.event_name == 'schedule' || ${{ needs.changes.outputs.agent == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -97,7 +99,7 @@ jobs:
     # build docker image for plugin tests, with matrix of Python versions
     name: Construct Agent Plugin Test Images
     needs: [ license-and-lint, changes, prep-plugin-and-unit-tests ]
-    if: ${{ needs.changes.outputs.agent == 'true' }}
+    if: github.event_name == 'schedule' || ${{ needs.changes.outputs.agent == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix: # may support pypy in the future
@@ -126,7 +128,7 @@ jobs:
     # this step is only run after passing building images + prep matrix + changes
     name: Execute Agent Plugin and Unit Tests
     needs: [ license-and-lint, changes, docker-plugin, prep-plugin-and-unit-tests ]
-    if: ${{ needs.changes.outputs.agent == 'true' }}
+    if: github.event_name == 'schedule' || ${{ needs.changes.outputs.agent == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -162,7 +164,7 @@ jobs:
     # build docker image for E2E tests, single Python version for now.
     name: Construct Agent E2E Test Images
     needs: [ license-and-lint, changes ]
-    if: ${{ needs.changes.outputs.agent == 'true' }}
+    if: github.event_name == 'schedule' || ${{ needs.changes.outputs.agent == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -187,7 +189,7 @@ jobs:
     # execute E2E tests with SkyWalking-infra-e2e with a matrix of agent protocols
     name: Basic function + ${{ matrix.case.name }} Transport (Python3.7)
     needs: [ license-and-lint, changes, docker-e2e ]
-    if: ${{ needs.changes.outputs.agent == 'true' }}
+    if: github.event_name == 'schedule' || ${{ needs.changes.outputs.agent == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
Changes action failed to find a base commit to compare changes in scheduled events because there's simply none.

Added a check for event type so we can always run the scheduled event regardless of base.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `tools/doc/plugin_doc_gen.py`
-->
