### PR TITLE
Fix multiple requests for the same traceId in Tornado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Drop support for flask 1.x due to dependency issue in Jinja2 and EOL (#195)
 
 - Fixes:
+  - Fix the problem of multiple requests for the same traceId in Tornado framework (#9133)
   - Spans now correctly reference finished parents (#161)
   - Remove potential password leak from Aiohttp outgoing url (#175)
   - Handle error when REMOTE_PORT is missing in Flask (#176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Drop support for flask 1.x due to dependency issue in Jinja2 and EOL (#195)
 
 - Fixes:
-  - Fix the problem of multiple requests for the same traceId in Tornado framework (#9133)
+  - Fix the problem of multiple requests for the same traceId in Tornado framework (#209)
   - Spans now correctly reference finished parents (#161)
   - Remove potential password leak from Aiohttp outgoing url (#175)
   - Handle error when REMOTE_PORT is missing in Flask (#176)

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -46,10 +46,7 @@ try:  # attempt to use async-local instead of thread-local context and spans
         return spans
 
     def _spans_dup():
-        spans = __spans.get()[:]
-        __spans.set(spans)
-
-        return spans
+        return __spans.get()
 
     __spans.set([])
 


### PR DESCRIPTION
- Fix the problem of multiple requests for the same traceId in Tornado framework

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `tools/doc/plugin_doc_gen.py`
-->
