### PR TITLE
Improved ignore path regex

### DIFF
--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -104,12 +104,14 @@ def finalize():
     method = r'^' + '|'.join(s.strip() for s in http_ignore_method.split(',')) + '$'
     path = '^(?:' + \
            '|'.join(  # replaces ","
-               '(?:(?:[^/]+/)*[^/]+)?'.join(  # replaces "**"
-                   '[^/]*'.join(  # replaces "*"
-                       '[^/]'.join(  # replaces "?"
-                           reesc.sub(r'\\\1', s) for s in p2.split('?')
-                       ) for p2 in p1.split('*')
-                   ) for p1 in p0.strip().split('**')
+               '/(?:[^/]*/)*'.join(  # replaces "/**/"
+                   '(?:(?:[^/]+/)*[^/]+)?'.join(  # replaces "**"
+                       '[^/]*'.join(  # replaces "*"
+                           '[^/]'.join(  # replaces "?"
+                               reesc.sub(r'\\\1', s) for s in p3.split('?')
+                           ) for p3 in p2.split('*')
+                       ) for p2 in p1.strip().split('**')
+                   ) for p1 in p0.split('/**/')
                ) for p0 in trace_ignore_path.split(',')
            ) + ')$'
 

--- a/tests/unit/test_ant_matcher.py
+++ b/tests/unit/test_ant_matcher.py
@@ -81,6 +81,10 @@ class TestFastPathMatch(unittest.TestCase):
         path = 'eureka/apps/test/list'
         self.assertTrue(fast_path_match(pattern, path))
         path = 'eureka/test/list'
+        self.assertTrue(fast_path_match(pattern, path))
+
+        pattern = 'eureka/*/**/test/**'
+        path = 'eureka/test/list'
         self.assertFalse(fast_path_match(pattern, path))
 
         pattern = '/eureka/**/b/**/*.txt'


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-bootstrap/src/main/resources/component-libraries.yml#L415)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `tools/doc/plugin_doc_gen.py`
-->
This is the same as skywalking-nodejs PR #81:

Minor enhancement/fix? Previously the config.trace_ignore_path pattern `/a/**/*` would match `/a/b/`, `/a/b/c` and `/a/b/c/`, etc... but not `/a/` or `/a/b`. Now it does.