### PR TITLE
feat: Add support for MeterReportService

### DIFF
--- a/docs/en/setup/advanced/MeterReporter.md
+++ b/docs/en/setup/advanced/MeterReporter.md
@@ -1,0 +1,110 @@
+# Python Agent Meter Reporter
+
+To enable or disable this feature, you will need to set some environment variables.
+
+
+## Enabling the feature (default)
+```Python 
+os.environ['SW_AGENT_METER_REPORTER_ACTIVE'] = 'True'
+``` 
+or
+```bash
+export SW_AGENT_METER_REPORTER_ACTIVE=True
+```
+
+## Disable the feature
+```Python 
+os.environ['SW_AGENT_METER_REPORTER_ACTIVE'] = 'False'
+``` 
+or
+```bash
+export SW_AGENT_METER_REPORTER_ACTIVE=False
+```
+## Counter
+* `Counter` API represents a single monotonically increasing counter, automatic collect data and report to backend.
+```python
+tg_ls = [MeterTag("key", "value")]
+c = Counter('c2', CounterMode.INCREMENT, tg_ls)
+# or with more compact way
+# Counter('c2', CounterMode.INCREMENT).tag('key1', 'value1').tag('key2', 'value2')
+c.build()
+c.increment(2)
+```
+### Syntactic sugars
+```python
+c = Counter('c2', CounterMode.INCREMENT)
+c.build()
+
+# increase Counter c by the time the with-wrapped codes consumed
+with c.create_timer():
+    # some codes may consume a certain time
+```
+
+```python
+c = Counter('c3', CounterMode.INCREMENT)
+c.build()
+
+# increase Counter c by num once counter_decorator_test gets called
+@Counter.increase(name='c3', num=2)
+def counter_decorator_test():
+    # some codes
+```
+
+```python
+c = Counter('c4', CounterMode.INCREMENT)
+c.build()
+
+# increase Counter c by the time counter_decorator_test consumed
+@Counter.timer(name='c4')
+def counter_decorator_test(s):
+    # some codes may consume a certain time
+```
+
+1. `Counter(name, tags)` Create a new counter with the meter name and optional tags.
+1. `Counter.tag(key: str, value)` Mark a tag key/value pair.
+1. `Counter.mode(mode: CounterMode)` Change the counter mode, RATE mode means reporting rate to the backend.
+1. `Counter.increment(count)` Increment count to the `Counter`, It could be a positive value.
+
+## Gauge
+* `Gauge` API represents a single numerical value.
+```python
+tg_ls = [MeterTag("key", "value")]
+# producer: iterable object
+g = Gauge('g1', producer, tg_ls)
+g.build()
+```
+1. `Gauge(name, tags)` Create a new gauge with the meter name and iterable object, this iterable object need to produce numeric value.
+1. `Gauge.tag(key: str, value)` Mark a tag key/value pair.
+1. `Gauge.build()` Build a new `Gauge` which is collected and reported to the backend.
+
+## Histogram
+* `Histogram` API represents a summary sample observations with customize buckets.
+```python
+tg_ls = [MeterTag("key", "value")]
+h = Histogram('h2', [i / 10 for i in range(10)], tg_ls)
+h.build()
+```
+### Syntactic sugars
+```python
+h = Histogram('h3', [i / 10 for i in range(10)])
+h.build()
+
+# Histogram h will record the time the with-wrapped codes consumed
+with h.create_timer():
+    # some codes may consume a certain time
+```
+
+```python
+h = Histogram('h2', [i / 10 for i in range(10)])
+h.build()
+
+# Histogram h will record the time histogram_decorator_test consumed
+@Histogram.timer(name='h2')
+def histogram_decorator_test(s):
+    time.sleep(s)
+```
+1. `Histogram(name, tags)` Create a new histogram with the meter name and optional tags.
+1. `Histogram.tag(key: str, value)` Mark a tag key/value pair.
+1. `Histogram.minValue(value)` Set up the minimal value of this histogram, default is `0`.
+1. `Histogram.build()` Build a new `Histogram` which is collected and reported to the backend.
+1. `Histogram.addValue(value)` Add value into the histogram, automatically analyze what bucket count needs to be increment. rule: count into [step1, step2).

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -40,6 +40,7 @@ __protocol = Protocol()  # type: Protocol
 __heartbeat_thread = __report_thread = __log_report_thread = __query_profile_thread = __command_dispatch_thread \
     = __send_profile_thread = meter_service_thread = __queue = __log_queue = __snapshot_queue = __finished = None
 
+
 def __heartbeat():
     wait = base = 30
 

--- a/skywalking/agent/protocol/__init__.py
+++ b/skywalking/agent/protocol/__init__.py
@@ -38,6 +38,9 @@ class Protocol(ABC):
     def report_log(self, queue: Queue, block: bool = True):
         raise NotImplementedError()
 
+    def report_meter(self, queue: Queue, block: bool = True):
+        raise NotImplementedError()
+
     def query_profile_commands(self):
         pass
 

--- a/skywalking/agent/protocol/grpc.py
+++ b/skywalking/agent/protocol/grpc.py
@@ -26,7 +26,7 @@ from skywalking import config
 from skywalking.agent import Protocol
 from skywalking.agent.protocol.interceptors import header_adder_interceptor
 from skywalking.client.grpc import GrpcServiceManagementClient, GrpcTraceSegmentReportService, \
-    GrpcProfileTaskChannelService, GrpcLogDataReportService
+    GrpcProfileTaskChannelService, GrpcLogDataReportService, GrpcMeterReportService
 from skywalking.loggings import logger, logger_debug_enabled
 from skywalking.profile.profile_task import ProfileTask
 from skywalking.profile.snapshot import TracingThreadSnapshot
@@ -57,6 +57,7 @@ class GrpcProtocol(Protocol):
         self.traces_reporter = GrpcTraceSegmentReportService(self.channel)
         self.profile_channel = GrpcProfileTaskChannelService(self.channel)
         self.log_reporter = GrpcLogDataReportService(self.channel)
+        self.meter_reporter = GrpcMeterReportService(self.channel)
 
     def _cb(self, state):
         if logger_debug_enabled:

--- a/skywalking/client/__init__.py
+++ b/skywalking/client/__init__.py
@@ -28,9 +28,11 @@ class TraceSegmentReportService(object):
     def report(self, generator):
         raise NotImplementedError()
 
+
 class MeterReportService(object):
     def report(self, generator):
         raise NotImplementedError()
+
 
 class LogDataReportService(object):
     def report(self, generator):

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -20,7 +20,7 @@ import grpc
 
 from skywalking import config
 from skywalking.client import ServiceManagementClient, TraceSegmentReportService, ProfileTaskChannelService, \
-    LogDataReportService
+    LogDataReportService, MeterReportService
 from skywalking.command import command_service
 from skywalking.loggings import logger, logger_debug_enabled
 from skywalking.profile import profile_task_execution_service
@@ -29,6 +29,7 @@ from skywalking.protocol.common.Common_pb2 import KeyStringValuePair
 from skywalking.protocol.language_agent.Tracing_pb2_grpc import TraceSegmentReportServiceStub
 from skywalking.protocol.logging.Logging_pb2_grpc import LogReportServiceStub
 from skywalking.protocol.management.Management_pb2 import InstancePingPkg, InstanceProperties
+from skywalking.protocol.language_agent.Meter_pb2_grpc import MeterReportServiceStub
 from skywalking.protocol.management.Management_pb2_grpc import ManagementServiceStub
 from skywalking.protocol.profile.Profile_pb2 import ProfileTaskCommandQuery, ProfileTaskFinishReport
 from skywalking.protocol.profile.Profile_pb2_grpc import ProfileTaskStub
@@ -69,6 +70,16 @@ class GrpcTraceSegmentReportService(TraceSegmentReportService):
     def __init__(self, channel: grpc.Channel):
         self.report_stub = TraceSegmentReportServiceStub(channel)
 
+    def report(self, generator):
+        self.report_stub.collect(generator)
+
+class GrpcMeterReportService(MeterReportService):
+    def __init__(self, channel: grpc.Channel):
+        self.report_stub = MeterReportServiceStub(channel)
+
+    def report_batch(self, generator):
+        self.report_stub.collectBatch(generator)
+    
     def report(self, generator):
         self.report_stub.collect(generator)
 

--- a/skywalking/client/grpc.py
+++ b/skywalking/client/grpc.py
@@ -73,13 +73,14 @@ class GrpcTraceSegmentReportService(TraceSegmentReportService):
     def report(self, generator):
         self.report_stub.collect(generator)
 
+
 class GrpcMeterReportService(MeterReportService):
     def __init__(self, channel: grpc.Channel):
         self.report_stub = MeterReportServiceStub(channel)
 
     def report_batch(self, generator):
         self.report_stub.collectBatch(generator)
-    
+
     def report(self, generator):
         self.report_stub.collect(generator)
 

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -87,7 +87,8 @@ log_reporter_layout: str = os.getenv('SW_AGENT_LOG_REPORTER_LAYOUT') or \
 cause_exception_depth: int = int(os.getenv('SW_AGENT_CAUSE_EXCEPTION_DEPTH') or '10')
 
 # meter reporter configurations
-meter_reporter_activate: bool = os.getenv('SW_AGENT_METER_REPORTER_ACTIVE') == 'True'
+meter_reporter_active: bool = os.getenv('SW_AGENT_METER_REPORTER_ACTIVE') == 'True'
+meter_reporter_max_buffer_size: int = int(os.getenv('SW_AGENT_METER_REPORTER_BUFFER_SIZE') or '10000')
 
 options = {key for key in globals() if key not in options}  # THIS MUST FOLLOW DIRECTLY AFTER LIST OF CONFIG OPTIONS!
 

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -89,6 +89,7 @@ cause_exception_depth: int = int(os.getenv('SW_AGENT_CAUSE_EXCEPTION_DEPTH') or 
 # meter reporter configurations
 meter_reporter_active: bool = os.getenv('SW_AGENT_METER_REPORTER_ACTIVE') == 'True'
 meter_reporter_max_buffer_size: int = int(os.getenv('SW_AGENT_METER_REPORTER_BUFFER_SIZE') or '10000')
+meter_reporter_peroid: int = int(os.getenv('SW_AGENT_METER_REPORTER_PEROID') or '20')
 
 options = {key for key in globals() if key not in options}  # THIS MUST FOLLOW DIRECTLY AFTER LIST OF CONFIG OPTIONS!
 

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -86,6 +86,9 @@ log_reporter_layout: str = os.getenv('SW_AGENT_LOG_REPORTER_LAYOUT') or \
 # This configuration is shared by log reporter and tracer
 cause_exception_depth: int = int(os.getenv('SW_AGENT_CAUSE_EXCEPTION_DEPTH') or '10')
 
+# meter reporter configurations
+meter_reporter_activate: bool = os.getenv('SW_AGENT_METER_REPORTER_ACTIVE') == 'True'
+
 options = {key for key in globals() if key not in options}  # THIS MUST FOLLOW DIRECTLY AFTER LIST OF CONFIG OPTIONS!
 
 

--- a/skywalking/meter/__init__.py
+++ b/skywalking/meter/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/skywalking/meter/__init__.py
+++ b/skywalking/meter/__init__.py
@@ -14,3 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+_meter_service = None
+
+
+def init():
+    from skywalking.meter.meter_service import MeterService
+
+    global _meter_service
+    if _meter_service:
+        return
+
+    _meter_service = MeterService()
+    _meter_service.start()

--- a/skywalking/meter/counter.py
+++ b/skywalking/meter/counter.py
@@ -73,6 +73,21 @@ class Counter(BaseMeter):
             self.metrics.increment(duration)
 
     @staticmethod
+    def timer(name: str):
+        def inner(func):
+            def wrapper(*args, **kwargs):
+                start = timeit.default_timer()
+                func(*args, **kwargs)
+                stop = timeit.default_timer()
+                duration = stop - start
+                counter = Counter.meter_service.get_meter(name)
+                counter.increment(duration)
+
+            return wrapper
+
+        return inner
+
+    @staticmethod
     def increase(name: str, num=1):
         def inner(func):
             def wrapper(*args, **kwargs):

--- a/skywalking/meter/gauge.py
+++ b/skywalking/meter/gauge.py
@@ -20,19 +20,18 @@ from skywalking.protocol.language_agent.Meter_pb2 import MeterData, MeterSingleV
 
 
 class Gauge(BaseMeter):
-    def __init__(self, name: str, generator, tags=[]):
+    def __init__(self, name: str, generator, tags=None):
         super().__init__(name, tags)
         self.generator = generator
-    
+
     def get(self):
         data = next(self.generator, None)
         return data if data else 0
-    
+
     def transform(self):
         count = self.get()
-        meterdata = MeterData(singleValue=MeterSingleValue(name=self.getName(), labels=self.transformTags(), value=count))
+        meterdata = MeterData(singleValue=MeterSingleValue(name=self.get_name(), labels=self.transform_tags(), value=count))
         return meterdata
-        
-    def getType(self):
+
+    def get_type(self):
         return MeterType.GAUGE
-    

--- a/skywalking/meter/gauge.py
+++ b/skywalking/meter/gauge.py
@@ -15,31 +15,24 @@
 # limitations under the License.
 #
 
-
-class ServiceManagementClient(object):
-    def send_instance_props(self):
-        raise NotImplementedError()
-
-    def send_heart_beat(self):
-        raise NotImplementedError()
+from skywalking.meter.meter import BaseMeter, MeterType
+from skywalking.protocol.language_agent.Meter_pb2 import MeterData, MeterSingleValue
 
 
-class TraceSegmentReportService(object):
-    def report(self, generator):
-        raise NotImplementedError()
-
-class MeterReportService(object):
-    def report(self, generator):
-        raise NotImplementedError()
-
-class LogDataReportService(object):
-    def report(self, generator):
-        raise NotImplementedError()
-
-
-class ProfileTaskChannelService(object):
-    def do_query(self):
-        raise NotImplementedError()
-
-    def send(self, generator):
-        raise NotImplementedError()
+class Gauge(BaseMeter):
+    def __init__(self, name: str, generator, tags=[]):
+        super().__init__(name, tags)
+        self.generator = generator
+    
+    def get(self):
+        data = next(self.generator, None)
+        return data if data else 0
+    
+    def transform(self):
+        count = self.get()
+        meterdata = MeterData(singleValue=MeterSingleValue(name=self.getName(), labels=self.transformTags(), value=count))
+        return meterdata
+        
+    def getType(self):
+        return MeterType.GAUGE
+    

--- a/skywalking/meter/histogram.py
+++ b/skywalking/meter/histogram.py
@@ -1,0 +1,135 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import timeit
+from skywalking.meter.meter import BaseMeter, MeterType
+from skywalking.protocol.language_agent.Meter_pb2 import MeterBucketValue, MeterData, MeterHistogram, MeterSingleValue
+
+
+class Histogram(BaseMeter):
+    def __init__(self, name: str, steps, minValue=0, tags=[]):
+        super().__init__(name, tags)
+        self.minValue = minValue
+
+        # https://stackoverflow.com/a/53522/9845190
+        if not steps:
+            # raise error
+            pass
+
+        # https://stackoverflow.com/a/2931683/9845190
+        steps = sorted(set(steps))
+
+        if steps[0] < self.minValue:
+            # raise error
+            pass
+        elif steps[0] != self.minValue:
+            steps.insert(0, self.minValue)
+        self.initBucks(steps)
+
+
+    def addValue(self, value):
+        bucket = self.findBucket(value)
+        if bucket == None:
+            return 
+        
+        bucket.increment(1)
+
+    def findBucket(self, value):
+        l = 0
+        r = len(self.buckets)
+        
+        # find the first bucket greater than or equal the value
+        while(l < r):
+            mid = (l + r) // 2
+            if(self.buckets[mid].bucket < value):
+                l = mid + 1
+            else:
+                r = mid
+        
+        l -= 1
+
+        return self.buckets[l] if l < len(self.buckets) and l >= 0 else None
+
+
+    def initBucks(self, steps):
+        self.buckets = [Histogram.Bucket(step) for step in steps]
+
+    def transform(self):
+        values = [bucket.transform() for bucket in self.buckets]
+        return MeterData(histogram=MeterHistogram(name=self.getName(), labels=self.transformTags(), values=values))
+    
+    def getType(self):
+        return MeterType.HISTOGRAM
+
+    def createTimer(self):
+        return Histogram.Timer(self)
+
+    class Bucket():
+        
+        def __init__(self, bucket):
+            self.bucket = bucket
+            self.count = 0
+        
+        def increment(self, count):
+            self.count += count
+
+        def transform(self):
+            return MeterBucketValue(bucket=self.bucket, count=self.count)
+        
+        def __hash__(self) -> int:
+            return hash((self.bucket, self.count))
+
+    class Timer():
+        def __init__(self, metrics):
+            self.metrics = metrics
+
+        def __enter__(self):
+            self.start = timeit.default_timer()
+            
+
+        def __exit__(self, exc_type, exc_value, exc_tb):
+            self.stop = timeit.default_timer()
+            duration = self.stop - self.start
+            self.metrics.addValue(duration)
+    
+    @staticmethod
+    def timer(name: str):
+        def Inner(func):
+            def wrapper(*args, **kwargs):
+                start = timeit.default_timer()
+                func(*args, **kwargs)
+                stop = timeit.default_timer()
+                duration = stop - start
+                histogram = Histogram.meter_service.getMeterByName(name)
+                histogram.addValue(duration)
+
+            return wrapper
+            
+        return Inner
+
+    @staticmethod
+    def addValtu(name: str, num):
+        def Inner(func):
+            def wrapper(*args, **kwargs):
+                func(*args, **kwargs)
+                histogram = Histogram.meter_service.getMeterByName(name)
+                histogram.addValue(num)
+
+            return wrapper
+            
+        return Inner
+

--- a/skywalking/meter/meter.py
+++ b/skywalking/meter/meter.py
@@ -16,9 +16,9 @@
 #
 
 from abc import ABC, abstractmethod
-from skywalking.protocol.language_agent.Meter_pb2 import Label
-
 from enum import Enum
+from skywalking.protocol.language_agent.Meter_pb2 import Label
+import skywalking.meter as meter
 
 
 class MeterType(Enum):
@@ -82,10 +82,10 @@ class BaseMeter(ABC):
     meter_service = None
 
     def __init__(self, name: str, tags=None):
+        if BaseMeter.meter_service is None:
+            BaseMeter.meter_service = meter._meter_service
+
         self.meterId = MeterId(name, self.get_type(), tags)
-        if not BaseMeter.meter_service:
-            from skywalking.agent import meter_service_thread
-            BaseMeter.meter_service = meter_service_thread
 
     def get_name(self):
         return self.meterId.get_name()

--- a/skywalking/meter/meter.py
+++ b/skywalking/meter/meter.py
@@ -1,0 +1,115 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABC, abstractmethod
+from skywalking.protocol.language_agent.Meter_pb2 import Label
+
+from enum import Enum
+class MeterType(Enum):
+     GAUGE = 1
+     COUNTER = 2
+     HISTOGRAM = 3
+
+class MeterTag():
+    def __init__(self, key: str, value: str):
+        self.key = key
+        self.value = value
+    
+    def __lt__(self, other):
+        if self.key != other.key:
+            return self.key < other.key
+        else:
+            return self.value < other.value
+    
+    def getKey(self):
+        return self.key
+    
+    def getValue(self):
+        return self.value
+
+    def __hash__(self) -> int:
+        return hash((self.key, self.value))
+
+class MeterId():
+    def __init__(self, name: str, type, tags: list) -> None:
+        self.name = name
+        self.type = type
+        self.tags = tags
+        self.labels = None
+    
+    def transformTags(self):
+        if self.labels != None:
+            return self.labels
+
+        self.labels = list(map(lambda tag: Label(name=tag.key, value=tag.value), self.tags))
+        return self.labels
+    
+    def getName(self):
+        return self.name
+    
+    def getTags(self):
+        return self.tags
+    
+    def getType(self):
+        return self.type
+    
+    def __hash__(self):
+        return hash((self.name, self.type, tuple(self.tags)))
+
+
+class BaseMeter():
+    meter_service = None
+    def __init__(self, name: str, tags=[]):
+        self.meterId = MeterId(name, self.getType(), tags)
+        if not BaseMeter.meter_service:
+            from skywalking.agent import meter_service_thread
+            BaseMeter.meter_service = meter_service_thread
+
+    def getName(self):
+        return self.meterId.getName()
+
+    def getTag(self, tagKey):
+        for tag in self.meterId.getTags():
+            if tag.getKey() == tagKey:
+                return tag.getValue()
+
+    def getId(self):
+        return self.meterId
+
+    def transformTags(self):
+        return self.getId().transformTags()
+    
+    def tag(self, name: str, value):
+        self.meterId.getTags().append(MeterTag(name, value))
+        return self
+
+    def build(self):
+        self.meterId.getTags().sort()
+        BaseMeter.meter_service.register(self)
+    
+    @abstractmethod
+    def getType(self):
+        pass
+
+    
+    @abstractmethod
+    def __enter__(self):
+        pass
+
+    @abstractmethod
+    def __exit__(self):
+        pass

--- a/skywalking/meter/meter_service.py
+++ b/skywalking/meter/meter_service.py
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from time import time
+from threading import Thread
+from skywalking import config
+from skywalking.meter.meter import BaseMeter
+
+class MeterService(Thread):
+    __finished = None
+    logger = None
+
+    def __init__(self, reporter, ___finished, _logger):
+        super().__init__()
+        if not MeterService.__finished:
+            MeterService.__finished = ___finished
+            MeterService.logger = _logger
+
+        self.meterMap = {}
+        self.reporter = reporter
+        
+    def register(self, meter: BaseMeter):
+        self.meterMap[meter.getId().getName()] = meter
+    
+    def getMeterByName(self, name: str):
+        return self.meterMap.get(name)
+
+    def send(self):
+
+        def transform(adapter):
+            meterdata = adapter.transform()
+            meterdata.service = config.service_name
+            meterdata.serviceInstance=config.service_instance
+            meterdata.timestamp=int(time()*1000)
+            return meterdata
+        
+        wait = base = 1
+
+        while not MeterService.__finished.is_set():
+            try:
+                meterdata_ls = [transform(meterdata) for meterdata in self.meterMap.values()]
+                generator = iter(meterdata_ls)
+                self.reporter.report(generator)
+                wait = base
+            except Exception as exc:
+                MeterService.logger.error(str(exc))
+                wait = min(60, wait * 2 or 1)
+
+            MeterService.__finished.wait(wait)
+
+
+    def run(self):
+        while(True):
+            self.send()
+
+    

--- a/skywalking/meter/meter_service.py
+++ b/skywalking/meter/meter_service.py
@@ -20,6 +20,7 @@ from threading import Thread
 from skywalking import config
 from skywalking.meter.meter import BaseMeter
 
+
 class MeterService(Thread):
     __finished = None
     logger = None
@@ -32,11 +33,11 @@ class MeterService(Thread):
 
         self.meterMap = {}
         self.reporter = reporter
-        
+
     def register(self, meter: BaseMeter):
-        self.meterMap[meter.getId().getName()] = meter
-    
-    def getMeterByName(self, name: str):
+        self.meterMap[meter.get_id().get_name()] = meter
+
+    def get_meter(self, name: str):
         return self.meterMap.get(name)
 
     def send(self):
@@ -44,10 +45,10 @@ class MeterService(Thread):
         def transform(adapter):
             meterdata = adapter.transform()
             meterdata.service = config.service_name
-            meterdata.serviceInstance=config.service_instance
-            meterdata.timestamp=int(time()*1000)
+            meterdata.serviceInstance = config.service_instance
+            meterdata.timestamp = int(time()*1000)
             return meterdata
-        
+
         wait = base = 1
 
         while not MeterService.__finished.is_set():
@@ -64,7 +65,5 @@ class MeterService(Thread):
 
 
     def run(self):
-        while(True):
+        while True:
             self.send()
-
-    

--- a/skywalking/meter/meter_service.py
+++ b/skywalking/meter/meter_service.py
@@ -22,6 +22,7 @@ from skywalking import config
 from skywalking import agent
 from skywalking.meter.meter import BaseMeter
 from skywalking.utils.time import current_milli_time
+from skywalking.config import meter_reporter_peroid
 
 
 class MeterService(Thread):
@@ -49,5 +50,5 @@ class MeterService(Thread):
 
     def run(self):
         while True:
-            time.sleep(1)
+            time.sleep(meter_reporter_peroid)
             self.send()

--- a/tests/unit/test_meter.py
+++ b/tests/unit/test_meter.py
@@ -1,0 +1,156 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import random
+import time
+
+from skywalking.meter.counter import Counter, CounterMode
+from skywalking.meter.histogram import Histogram
+from skywalking.meter.gauge import Gauge
+from skywalking.meter.meter import BaseMeter
+
+class MockMeterService():
+    def __init__(self):
+        self.meterMap = {}
+        
+    def register(self, meter: BaseMeter):
+        self.meterMap[meter.getId().getName()] = meter
+
+    def getMeterByName(self, name: str):
+        return self.meterMap.get(name)
+    
+    def transform(self, meter):
+        meterdata = meter.transform()
+        meterdata.service = 'service_name'
+        meterdata.serviceInstance = 'service_instance'
+        meterdata.timestamp=int(0)
+        return meterdata
+
+meter_service = MockMeterService()
+BaseMeter.meter_service = meter_service
+
+class TestMeter(unittest.TestCase):
+    def test_counter(self):
+        c = Counter("c1", CounterMode.INCREMENT)
+        c.build()
+
+        @Counter.increase(name="c1")
+        def increase_by_one():
+            # do nothing
+            pass
+        
+        for i in range(1, 52):
+            increase_by_one()
+            self.assertEqual(i, c.count)
+            meterdata = meter_service.transform(c)
+            self.assertEqual(i, meterdata.singleValue.value)
+        
+    def test_counter_with_satement(self):
+        c = Counter("c2", CounterMode.INCREMENT)
+        c.build()
+
+        ls = [i / 10 for i in range(10)]         
+        random.shuffle(ls)
+        
+        pre = 0
+        for i in ls:
+            with c.createTimer():
+                time.sleep(i)
+            
+            meterdata = meter_service.transform(c)
+            a = int(i * 10)
+            b = int((meterdata.singleValue.value - pre) * 10)
+            pre = meterdata.singleValue.value
+            self.assertEqual(meterdata.singleValue.value, c.count)
+            self.assertAlmostEqual(a, b)
+            
+    def test_counter_decarator(self):
+        c = Counter("c3", CounterMode.INCREMENT)
+        c.build()
+        
+        @Counter.increase(name="c3", num=2)
+        def counter_decorator_test():
+            # do nothing
+            pass
+        
+        for i in range(1, 10):
+            counter_decorator_test()
+            meterdata = meter_service.transform(c)
+            self.assertEqual(i * 2, meterdata.singleValue.value)
+
+    def test_histogram(self):
+        h = Histogram("h1", [i for i in range(10)])
+        h.build()
+
+        for repeat in range(1, 10):
+            ls = list(range(1, 10))
+            random.shuffle(ls)
+
+            for i in ls:
+                h.addValue(i)
+                self.assertEqual(repeat, h.findBucket(i).count)
+                meterdata = meter_service.transform(h)
+                self.assertEqual(repeat, meterdata.histogram.values[i - 1].count)
+
+    def test_histogram_timer_decarator(self):
+        h = Histogram("h2", [i / 10 for i in range(10)])
+        h.build()
+
+        ls = [i / 10 for i in range(10)]
+        
+        @Histogram.timer(name="h2")
+        def histogram_decorator_test(s):
+            time.sleep(s)
+        
+        for repeat in range(1, 5):
+            random.shuffle(ls)
+            for i in ls:
+                histogram_decorator_test(i)
+                idx = int(i * 10)
+                meterdata = meter_service.transform(h)
+                self.assertEqual(repeat, meterdata.histogram.values[idx].count)
+
+    def test_histogram_with_satement(self):
+        h = Histogram("h3", [i / 10 for i in range(10)])
+        h.build()
+
+        ls = [i / 10 for i in range(10)]
+
+        for repeat in range(1, 5):
+            random.shuffle(ls)
+            for i in ls:
+                with h.createTimer():
+                    time.sleep(i)
+                idx = int(i * 10)
+                meterdata = meter_service.transform(h)
+                self.assertEqual(repeat, meterdata.histogram.values[idx].count)
+
+
+    def test_gauge(self):
+        ls = list(range(1, 10))
+        random.shuffle(ls)
+        g = Gauge("g1", iter(ls))
+        g.build()
+
+        for i in ls:
+            meterdata = meter_service.transform(g)
+            self.assertEqual(i, meterdata.singleValue.value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_meter.py
+++ b/tests/unit/test_meter.py
@@ -27,13 +27,13 @@ from skywalking.meter.meter import BaseMeter
 
 class MockMeterService():
     def __init__(self):
-        self.meterMap = {}
+        self.meter_map = {}
 
     def register(self, meter: BaseMeter):
-        self.meterMap[meter.get_id().get_name()] = meter
+        self.meter_map[meter.get_id().get_name()] = meter
 
     def get_meter(self, name: str):
-        return self.meterMap.get(name)
+        return self.meter_map.get(name)
 
     def transform(self, meter):
         meterdata = meter.transform()


### PR DESCRIPTION
Add support for MeterReportService

# Behavior
This service runs along with the agent like other services and reports roughly every 20 seconds.

## Syntactic sugar
### Counter
```python
c = Counter('c2', CounterMode.INCREMENT)
c.build()

# increase Counter c by the time the with-wrapped codes consumed
with c.create_timer():
    # some codes may consume a certain time
```

```python
c = Counter('c3', CounterMode.INCREMENT)
c.build()

# increase Counter c by num once counter_decorator_test gets called
@Counter.increase(name='c3', num=2)
def counter_decorator_test():
    # some codes
```

```python
c = Counter('c4', CounterMode.INCREMENT)
c.build()

# increase Counter c by the time counter_decorator_test consumed
@Counter.timer(name='c4')
def counter_decorator_test(s):
    # some codes may consume a certain time
```
### Histogram

```python
h = Histogram('h3', [i / 10 for i in range(10)])
h.build()

# Histogram h will record the time the with-wrapped codes consumed
with h.create_timer():
    # some codes may consume a certain time
```

```python
h = Histogram('h2', [i / 10 for i in range(10)])
h.build()

# Histogram h will record the time histogram_decorator_test consumed
@Histogram.timer(name='h2')
def histogram_decorator_test(s):
    time.sleep(s)
```

# Simple test
insert following codes below this line ``agent/__init__.py#L151``
```python
from skywalking.meter.gauge import Gauge
import gc

def generator_for_gc_g0():
    while(True):
        yield gc.get_stats()[0]['collected']

def generator_for_gc_g1():
    while(True):
        yield gc.get_stats()[1]['collected']

def generator_for_gc_g2():
    while(True):
        yield gc.get_stats()[2]['collected']


gc_g0_meter = Gauge("gc_g0", generator_for_gc_g0())
gc_g0_meter.build()

gc_g1_meter = Gauge("gc_g1", generator_for_gc_g1())
gc_g1_meter.build()

gc_g2_meter = Gauge("gc_g2", generator_for_gc_g2())
gc_g2_meter.build()
```