### PR TITLE
style: deal with B024 added to flake8 recently

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from skywalking.trace.context import Segment
 
 __started = False
-__protocol = Protocol()  # type: Protocol
+__protocol = None  # type: Protocol
 __heartbeat_thread = __report_thread = __log_report_thread = __query_profile_thread = __command_dispatch_thread \
     = __send_profile_thread = __queue = __log_queue = __snapshot_queue = __finished = None
 

--- a/skywalking/agent/protocol/__init__.py
+++ b/skywalking/agent/protocol/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from queue import Queue
 
 
@@ -29,12 +29,15 @@ class Protocol(ABC):
     def fork_after_in_child(self):
         pass
 
+    @abstractmethod
     def heartbeat(self):
         raise NotImplementedError()
 
+    @abstractmethod
     def report(self, queue: Queue, block: bool = True):
         raise NotImplementedError()
 
+    @abstractmethod
     def report_log(self, queue: Queue, block: bool = True):
         raise NotImplementedError()
 

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -16,7 +16,6 @@
 #
 
 import time
-from abc import ABC
 from collections import defaultdict
 from typing import List, Union, DefaultDict
 from typing import TYPE_CHECKING
@@ -33,7 +32,12 @@ if TYPE_CHECKING:
 
 
 @tostring
-class Span(ABC):
+class Span:
+    def __new__(cls, *args, **kwargs):
+        if cls is Span:
+            raise TypeError(f"only children of '{cls.__name__}' may be instantiated")
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(
             self,
             context: 'SpanContext',

--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -33,11 +33,6 @@ if TYPE_CHECKING:
 
 @tostring
 class Span:
-    def __new__(cls, *args, **kwargs):
-        if cls is Span:
-            raise TypeError(f"only children of '{cls.__name__}' may be instantiated")
-        return super().__new__(cls, *args, **kwargs)
-
     def __init__(
             self,
             context: 'SpanContext',

--- a/tests/plugin/base.py
+++ b/tests/plugin/base.py
@@ -18,7 +18,6 @@
 import inspect
 import os
 import sys
-from abc import ABC
 from difflib import Differ
 from os.path import dirname
 
@@ -32,7 +31,7 @@ except ImportError:
     from yaml import SafeLoader as Loader
 
 
-class TestPluginBase(ABC):
+class TestPluginBase:
     def validate(self, expected_file_name=None):
         # type: (str) -> Response
 


### PR DESCRIPTION
More details about B024 here https://github.com/PyCQA/flake8-bugbear/pull/274

## ./skywalking/agent/protocol/__init__.py:22:1: B024 Protocol is an abstract base class, but it has no abstract methods.
Set 'heartbeat', 'report' and 'report_log' as abstract method

## ./skywalking/trace/span.py:36:1: B024 Span is an abstract base class, but it has no abstract methods.
~Prevent base class Span from being directly instantiated by raising error in ``__new__`` with reference to
https://stackoverflow.com/questions/7989042/preventing-a-class-from-direct-instantiation-in-python~

## ./tests/plugin/base.py:35:1: B024 TestPluginBase is an abstract base class
Due to pytest instantiating parent class ~for searching test functions~, TestPluginBase has to be instantiable.

