### PR TITLE
Fix dead link due to the 'next' url change

### DIFF
--- a/docs/en/setup/faq/How-to-use-with-uwsgi.md
+++ b/docs/en/setup/faq/How-to-use-with-uwsgi.md
@@ -8,7 +8,7 @@ When uWSGI is used with Skywalking, the pre-fork mechanism of uWSGI must be cons
 
 If you get some problems when using skywalking, you can try to use the following method to call [`@postfork`](https://uwsgi-docs.readthedocs.io/en/latest/PythonDecorators.html#uwsgidecorators.postfork), the low-level api of uWSGI to initialize the skywalking client.
 
-The following is an example of the use of uWSGI and flask, the initialization parameters of skywalking can be referred to [Legacy Setup](https://skywalking.apache.org/docs/skywalking-python/latest/en/setup/intrusive/#legacy-setup)
+The following is an example of the use of uWSGI and flask, the initialization parameters of skywalking can be referred to [Legacy Setup](https://skywalking.apache.org/docs/skywalking-python/next/en/setup/intrusive/#legacy-setup)
 
 ```python
 # main.py


### PR DESCRIPTION
Fixing the only URL affected since we changed `latest` to `next`.
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
