### PR TITLE
style: deal with B026 reported by flake8

### DIFF
--- a/skywalking/plugins/sw_amqp.py
+++ b/skywalking/plugins/sw_amqp.py
@@ -55,7 +55,8 @@ def install():
 
     def _sw_basic_consume(self, queue='', consumer_tag='', no_local=False,
                           no_ack=False, exclusive=False, nowait=False,
-                          callback=None, *args, **kwargs):
+                          callback=None, arguments=None, on_cancel=None,
+                          argsig='BssbbbbF'):
         def _callback(msg):
             peer = getattr(self.connection, 'host', '<unavailable>')
             delivery_info = getattr(msg, 'delivery_info', {})
@@ -81,7 +82,8 @@ def install():
                 return callback(msg)
 
         return _basic_consume(self, queue=queue, consumer_tag=consumer_tag, no_local=no_local, no_ack=no_ack,
-                              exclusive=exclusive, nowait=nowait, callback=_callback, *args, **kwargs)
+                              exclusive=exclusive, nowait=nowait, callback=_callback, arguments=arguments,
+                              on_cancel=on_cancel, argsig=argsig)
 
     _basic_publish = Channel.basic_publish
     _basic_consume = Channel.basic_consume


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
B026 - Argument unpacking after keyword argument
https://github.com/PyCQA/flake8-bugbear/pull/287