### PR TITLE
feat: make some meter methods thread safe

### DIFF
--- a/skywalking/meter/counter.py
+++ b/skywalking/meter/counter.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import threading
 import timeit
 from enum import Enum
 from skywalking.meter.meter import BaseMeter, MeterType
@@ -32,9 +33,11 @@ class Counter(BaseMeter):
         self.count = 0
         self.previous = 0
         self.mode = mode
+        self._lock = threading.Lock()
 
     def increment(self, value):
-        self.count += value
+        with self._lock:
+            self.count += value
 
     def get(self):
         return self.count

--- a/skywalking/meter/counter.py
+++ b/skywalking/meter/counter.py
@@ -45,8 +45,8 @@ class Counter(BaseMeter):
     def transform(self):
         current_value = self.get()
         if self.mode == CounterMode.RATE:
-            self.previous = current_value
             count = current_value - self.previous
+            self.previous = current_value
         else:
             count = current_value
 

--- a/skywalking/meter/histogram.py
+++ b/skywalking/meter/histogram.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import threading
 import timeit
 from skywalking.meter.meter import BaseMeter, MeterType
 from skywalking.protocol.language_agent.Meter_pb2 import MeterBucketValue, MeterData, MeterHistogram
@@ -79,13 +80,14 @@ class Histogram(BaseMeter):
         return Histogram.Timer(self)
 
     class Bucket():
-
         def __init__(self, bucket):
             self.bucket = bucket
             self.count = 0
+            self._lock = threading.Lock()
 
         def increment(self, count):
-            self.count += count
+            with self._lock:
+                self.count += count
 
         def transform(self):
             return MeterBucketValue(bucket=self.bucket, count=self.count)


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->

Fulfill requirements of [aiops](https://github.com/SkyAPM/aiops-engine-for-skywalking) and make Python agent‘s behaviors consistent with the Java agent's.

refers to https://github.com/apache/skywalking-java/tree/main/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/meter