### PR TITLE
Update span.py

### DIFF
--- a/skywalking/trace/span.py
+++ b/skywalking/trace/span.py
@@ -174,7 +174,7 @@ class EntrySpan(Span):
     def start(self):
         Span.start(self)
         self._max_depth = self._depth
-        self.component = 0
+        self.component = Component.Unknown
         self.layer = Layer.Unknown
         self.logs = []
         self.tags = defaultdict(list)


### PR DESCRIPTION
span.component should not be started as an Enum instead of a int 0. integer 0 will be invalid if we just new_entry_span() without any further setting for span.component.

<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
