### PR TITLE
feat: add Kafka support to MeterReportService

### DIFF
--- a/skywalking/client/kafka.py
+++ b/skywalking/client/kafka.py
@@ -80,7 +80,7 @@ class KafkaServiceManagementClient(ServiceManagementClient):
         )
 
         key = bytes(self.topic_key_register + instance.serviceInstance, encoding='utf-8')
-        value = bytes(instance.SerializeToString())
+        value = instance.SerializeToString()
         self.producer.send(topic=self.topic, key=key, value=value)
 
     def send_heart_beat(self):
@@ -97,7 +97,7 @@ class KafkaServiceManagementClient(ServiceManagementClient):
         )
 
         key = bytes(instance_ping_pkg.serviceInstance, encoding='utf-8')
-        value = bytes(instance_ping_pkg.SerializeToString())
+        value = instance_ping_pkg.SerializeToString()
         future = self.producer.send(topic=self.topic, key=key, value=value)
         res = future.get(timeout=10)
         if logger_debug_enabled:
@@ -112,7 +112,7 @@ class KafkaTraceSegmentReportService(TraceSegmentReportService):
     def report(self, generator):
         for segment in generator:
             key = bytes(segment.traceSegmentId, encoding='utf-8')
-            value = bytes(segment.SerializeToString())
+            value = segment.SerializeToString()
             self.producer.send(topic=self.topic, key=key, value=value)
 
 
@@ -124,7 +124,7 @@ class KafkaLogDataReportService(LogDataReportService):
     def report(self, generator):
         for log_data in generator:
             key = bytes(log_data.traceContext.traceSegmentId, encoding='utf-8')
-            value = bytes(log_data.SerializeToString())
+            value = log_data.SerializeToString()
             self.producer.send(topic=self.topic, key=key, value=value)
 
 
@@ -137,7 +137,7 @@ class KafkaMeterDataReportService(MeterReportService):
         collection = MeterDataCollection()
         collection.meterData.extend(list(generator))
         key = bytes(config.service_instance, encoding='utf-8')
-        value = bytes(collection.SerializeToString())
+        value = collection.SerializeToString()
         self.producer.send(topic=self.topic, key=key, value=value)
 
 

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -38,6 +38,7 @@ kafka_bootstrap_servers: str = os.getenv('SW_KAFKA_REPORTER_BOOTSTRAP_SERVERS') 
 kafka_topic_management: str = os.getenv('SW_KAFKA_REPORTER_TOPIC_MANAGEMENT') or 'skywalking-managements'
 kafka_topic_segment: str = os.getenv('SW_KAFKA_REPORTER_TOPIC_SEGMENT') or 'skywalking-segments'
 kafka_topic_log: str = os.getenv('SW_KAFKA_REPORTER_TOPIC_LOG') or 'skywalking-logs'
+kafka_topic_meter: str = os.getenv('SW_KAFKA_REPORTER_TOPIC_METER') or 'skywalking-meters'
 force_tls: bool = os.getenv('SW_AGENT_FORCE_TLS', '').lower() == 'true'
 protocol: str = (os.getenv('SW_AGENT_PROTOCOL') or 'grpc').lower()
 authentication: str = os.getenv('SW_AGENT_AUTHENTICATION')

--- a/tests/e2e/case/grpc/e2e.yaml
+++ b/tests/e2e/case/grpc/e2e.yaml
@@ -61,9 +61,7 @@ verify:
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql instance list --service-name=e2e-service-provider
       expected: ../expected/service-instance.yml
 
-    # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
-    # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
-    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    # service instance pvm metrics
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name meter_total_cpu_utilization --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
       expected: ../expected/metrics-has-value.yml
 

--- a/tests/e2e/case/kafka/e2e.yaml
+++ b/tests/e2e/case/kafka/e2e.yaml
@@ -61,9 +61,7 @@ verify:
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql instance list --service-name=e2e-service-provider
       expected: ../expected/service-instance.yml
 
-    # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
-    # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
-    # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+    # service instance pvm metrics
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name meter_total_cpu_utilization --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
       expected: ../expected/metrics-has-value.yml
 

--- a/tests/e2e/case/kafka/e2e.yaml
+++ b/tests/e2e/case/kafka/e2e.yaml
@@ -64,8 +64,8 @@ verify:
     # TODO: Metric Collection Implementation is not merged https://github.com/apache/skywalking/issues/7084
     # service instance pvm metrics TODO: PVM Collection Implementation needed https://github.com/apache/skywalking/issues/5944
     # swctl --display yaml --base-url=http://localhost:12800/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
-    #    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name instance_jvm_thread_live_count --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
-    #      expected: ../expected/metrics-has-value.yml
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name meter_total_cpu_utilization --instance-name=provider1 --service-name=e2e-service-provider |yq e 'to_entries' -
+      expected: ../expected/metrics-has-value.yml
 
     # trace segment list
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
https://github.com/apache/skywalking-python/pull/238

OAP accepts `MeterDataCollection` only now.
Thanks to @Superskyyy's assistance to figure this out.