### PR TITLE
fix: Ignore websocket connections inside fastapi temporarily

### DIFF
--- a/skywalking/plugins/sw_fastapi.py
+++ b/skywalking/plugins/sw_fastapi.py
@@ -42,6 +42,10 @@ def install():
     async def _sw_fast_api(self, scope: Scope, receive: Receive, send: Send):
         from starlette.requests import Request
 
+        if scope['type'] == 'websocket':
+            resp = await _original_fast_api(self, scope, receive, send)
+            return resp
+
         req = Request(scope, receive=receive, send=send)
         carrier = Carrier()
         method = req.method


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
closes https://github.com/apache/skywalking/issues/9724
Ignore websocket connections inside fastapi for now until better solutions are proposed.