### PR TITLE
fix: GCDataSource.gc_time_generator

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -150,6 +150,18 @@ def __init_threading():
         __meter_report_thread = Thread(name='MeterReportThread', target=__report_meter, daemon=True)
         __meter_report_thread.start()
 
+        if config.pvm_meter_reporter_active:
+            from skywalking.meter.pvm.cpu_usage import CPUUsageDataSource
+            from skywalking.meter.pvm.gc_data import GCDataSource
+            from skywalking.meter.pvm.mem_usage import MEMUsageDataSource
+            from skywalking.meter.pvm.thread_data import ThreadDataSource
+
+            MEMUsageDataSource().registry()
+            CPUUsageDataSource().registry()
+            GCDataSource().registry()
+            ThreadDataSource().registry()
+
+
     if config.log_reporter_active:
         __log_queue = Queue(maxsize=config.log_reporter_max_buffer_size)
         __log_report_thread = Thread(name='LogReportThread', target=__report_log, daemon=True)

--- a/skywalking/agent/protocol/__init__.py
+++ b/skywalking/agent/protocol/__init__.py
@@ -19,16 +19,7 @@ from abc import ABC, abstractmethod
 from queue import Queue
 
 
-class Protocol(ABC):
-    def fork_before(self):
-        pass
-
-    def fork_after_in_parent(self):
-        pass
-
-    def fork_after_in_child(self):
-        pass
-
+class BaseProtocol(ABC):
     @abstractmethod
     def heartbeat(self):
         raise NotImplementedError()
@@ -41,8 +32,19 @@ class Protocol(ABC):
     def report_log(self, queue: Queue, block: bool = True):
         raise NotImplementedError()
 
+
+class Protocol(BaseProtocol):
+    def fork_before(self):
+        pass
+
+    def fork_after_in_parent(self):
+        pass
+
+    def fork_after_in_child(self):
+        pass
+
     def report_meter(self, queue: Queue, block: bool = True):
-        raise NotImplementedError()
+        pass
 
     def query_profile_commands(self):
         pass

--- a/skywalking/meter/__init__.py
+++ b/skywalking/meter/__init__.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from skywalking import config
-
 _meter_service = None
 
 
@@ -29,14 +27,3 @@ def init():
 
     _meter_service = MeterService()
     _meter_service.start()
-
-    if config.pvm_meter_reporter_active:
-        from skywalking.meter.pvm.cpu_usage import CPUUsageDataSource
-        from skywalking.meter.pvm.gc_data import GCDataSource
-        from skywalking.meter.pvm.mem_usage import MEMUsageDataSource
-        from skywalking.meter.pvm.thread_data import ThreadDataSource
-
-        MEMUsageDataSource().registry()
-        CPUUsageDataSource().registry()
-        GCDataSource().registry()
-        ThreadDataSource().registry()

--- a/skywalking/meter/pvm/gc_data.py
+++ b/skywalking/meter/pvm/gc_data.py
@@ -34,15 +34,17 @@ class GCDataSource(DataSource):
         while (True):
             yield gc.get_stats()[2]['collected']
 
-    def gc_callback(self, phase, info):
-        if phase == 'start':
-            self.start_time = time.time()
-        elif phase == 'stop':
-            self.gc_time = time.time() - self.start_time
-
     def gc_time_generator(self):
+        self.gc_time = 0
+
+        def gc_callback(phase, info):
+            if phase == 'start':
+                self.start_time = time.time()
+            elif phase == 'stop':
+                self.gc_time = (time.time() - self.start_time) * 1000
+
         if hasattr(gc, 'callbacks'):
-            gc.callbacks.append(self.gc_callback)
+            gc.callbacks.append(gc_callback)
 
         while (True):
             yield self.gc_time


### PR DESCRIPTION
<!-- Uncomment the following checklist WHEN AND ONLY WHEN you're adding a new plugin -->
<!--
- [ ] Add a test case for the new plugin
- [ ] Add a CHANGELOG entry for the new plugin
- [ ] Add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] Rebuild the `requirements.txt` by running `tools/env/build_requirements_(linux|windows).sh`
- [ ] Rebuild the `Plugins.md` documentation by running `make doc-gen`
-->
`self.gc_time` is invalid without advance definition.
Sorry for making such a low-level mistake.

P.S. flake8 updates again.