### PR TITLE
Add namespace suffix to service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
   - Fix sw_logging (log reporter) potentially throw exception leading to traceback confusion (#267)
   - Avoid reporting meaningless tracecontext with logs when there's no active span, UI will now show empty traceID (#272)
   - Fix exception handler in profile_context (#273)
-  
+  - Add namespace suffix to service name (#275)
+
 - Docs:
   - New documentation on how to test locally (#222)
   - New documentation on the newly added meter reporter feature (#240)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ else
     OS := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
 endif
 
+.PHONY: env
+env: poetry gen
+	poetry install
+	poetry run pip install --upgrade pip
+
 .PHONY: poetry poetry-fallback
 # poetry installer may not work on macOS's default python
 # falls back to pipx installer
@@ -57,12 +62,6 @@ gen-basic:
 install: gen-basic
 	python3 -m pip install --upgrade pip
 	python3 -m pip install .[all]
-
-.PHONY: env
-env: poetry gen
-	poetry install
-	poetry run pip install --upgrade pip
-
 
 .PHONY: lint
 # flake8 configurations should go to the file setup.cfg

--- a/docs/en/setup/Configuration.md
+++ b/docs/en/setup/Configuration.md
@@ -21,7 +21,7 @@ export SW_AGENT_YourConfiguration=YourValue
 | protocol | SW_AGENT_PROTOCOL | <class 'str'> | grpc | The protocol to communicate with the backend OAP, `http`, `grpc` or `kafka`, **we highly suggest using `grpc` in production as it's well optimized than `http`**. The `kafka` protocol provides an alternative way to submit data to the backend. |
 | service_name | SW_AGENT_SERVICE_NAME | <class 'str'> | Python Service Name | The name of your awesome Python service |
 | service_instance | SW_AGENT_SERVICE_INSTANCE | <class 'str'> | str(uuid.uuid1()).replace('-', '') | The name of this particular awesome Python service instance |
-| namespace | SW_AGENT_NAMESPACE | <class 'str'> |  | The agent namespace of the Python service (available as tag) |
+| namespace | SW_AGENT_NAMESPACE | <class 'str'> |  | The agent namespace of the Python service (available as tag and the suffix of service name) |
 | kafka_bootstrap_servers | SW_AGENT_KAFKA_BOOTSTRAP_SERVERS | <class 'str'> | localhost:9092 | A list of host/port pairs to use for establishing the initial connection to your Kafka cluster. It is in the form of host1:port1,host2:port2,... (used for Kafka reporter protocol) |
 | kafka_topic_management | SW_AGENT_KAFKA_TOPIC_MANAGEMENT | <class 'str'> | skywalking-managements | Specifying Kafka topic name for service instance reporting and registering, this should be in sync with OAP |
 | kafka_topic_segment | SW_AGENT_KAFKA_TOPIC_SEGMENT | <class 'str'> | skywalking-segments | Specifying Kafka topic name for Tracing data, this should be in sync with OAP |

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -54,7 +54,7 @@ protocol: str = os.getenv('SW_AGENT_PROTOCOL', 'grpc').lower()
 service_name: str = os.getenv('SW_AGENT_SERVICE_NAME', 'Python Service Name')
 # The name of this particular awesome Python service instance
 service_instance: str = os.getenv('SW_AGENT_SERVICE_INSTANCE', str(uuid.uuid1()).replace('-', ''))
-# The agent namespace of the Python service (available as tag)
+# The agent namespace of the Python service (available as tag and the suffix of service name)
 namespace: str = os.getenv('SW_AGENT_NAMESPACE', '')
 # A list of host/port pairs to use for establishing the initial connection to your Kafka cluster.
 # It is in the form of host1:port1,host2:port2,... (used for Kafka reporter protocol)
@@ -218,7 +218,22 @@ def init(**kwargs) -> None:
         glob[key] = val
 
 
-def finalize():
+def finalize_service_name() -> None:
+    """
+    This function concatenates the serviceName according to
+    Java agent's implementation.
+    TODO: add kafka namespace prefix and cluster concept
+    Ref https://github.com/apache/skywalking-java/pull/123
+    """
+    global service_name
+    if namespace:
+        service_name = f'{service_name}|{namespace}'
+
+
+def finalize_regex() -> None:
+    """
+    Build path matchers based on user provided regex expressions
+    """
     reesc = re.compile(r'([.*+?^=!:${}()|\[\]\\])')
     suffix = r'^.+(?:' + '|'.join(reesc.sub(r'\\\1', s.strip()) for s in ignore_suffix.split(',')) + ')$'
     method = r'^' + '|'.join(s.strip() for s in http_ignore_method.split(',')) + '$'
@@ -242,3 +257,11 @@ def finalize():
 
 def ignore_http_method_check(method: str):
     return RE_HTTP_IGNORE_METHOD.match(method)
+
+
+def finalize() -> None:
+    """
+    invokes finalizers
+    """
+    finalize_regex()
+    finalize_service_name()

--- a/skywalking/config.py
+++ b/skywalking/config.py
@@ -218,7 +218,7 @@ def init(**kwargs) -> None:
         glob[key] = val
 
 
-def finalize_service_name() -> None:
+def finalize_name() -> None:
     """
     This function concatenates the serviceName according to
     Java agent's implementation.
@@ -264,4 +264,4 @@ def finalize() -> None:
     invokes finalizers
     """
     finalize_regex()
-    finalize_service_name()
+    finalize_name()

--- a/tests/e2e/base/docker-compose.base.yml
+++ b/tests/e2e/base/docker-compose.base.yml
@@ -65,6 +65,7 @@ services:
     environment:
       SW_AGENT_SERVICE_NAME: e2e-service-consumer
       SW_AGENT_SERVICE_INSTANCE: consumer1
+      SW_AGENT_NAMESPACE: namespace
       SW_AGENT_LOGGING_LEVEL: DEBUG
     healthcheck:
       test: [ "CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090" ]

--- a/tests/e2e/case/expected/service.yml
+++ b/tests/e2e/case/expected/service.yml
@@ -21,8 +21,8 @@
     - GENERAL
   group: ""
 - id: {{ b64enc "e2e-service-consumer|namespace" }}.1
-  name: e2e-service-consumer|namespace
-  shortname: e2e-service-consumer|namespace
+  name: "e2e-service-consumer|namespace"
+  shortname: "e2e-service-consumer|namespace"
   normal: true
   layers:
     - GENERAL

--- a/tests/e2e/case/expected/service.yml
+++ b/tests/e2e/case/expected/service.yml
@@ -20,9 +20,9 @@
   layers:
     - GENERAL
   group: ""
-- id: {{ b64enc "e2e-service-consumer" }}.1
-  name: e2e-service-consumer
-  shortname: e2e-service-consumer
+- id: {{ b64enc "e2e-service-consumer|namespace" }}.1
+  name: e2e-service-consumer|namespace
+  shortname: e2e-service-consumer|namespace
   normal: true
   layers:
     - GENERAL

--- a/tests/e2e/case/expected/trace-artist-detail.yml
+++ b/tests/e2e/case/expected/trace-artist-detail.yml
@@ -20,7 +20,7 @@ spans:
   spanid: {{ .spanid }}
   parentspanid: {{ .parentspanid }}
   refs: []
-  servicecode: e2e-service-consumer|namespace
+  servicecode: "e2e-service-consumer|namespace"
   serviceinstancename: consumer1
   starttime: {{ gt .starttime 0 }}
   endtime: {{ gt .endtime 0 }}
@@ -46,7 +46,7 @@ spans:
   spanid: {{ .spanid }}
   parentspanid: {{ .parentspanid }}
   refs: []
-  servicecode: e2e-service-consumer|namespace
+  servicecode: "e2e-service-consumer|namespace"
   serviceinstancename: consumer1
   starttime: {{ gt .starttime 0 }}
   endtime: {{ gt .endtime 0 }}

--- a/tests/e2e/case/expected/trace-artist-detail.yml
+++ b/tests/e2e/case/expected/trace-artist-detail.yml
@@ -20,7 +20,7 @@ spans:
   spanid: {{ .spanid }}
   parentspanid: {{ .parentspanid }}
   refs: []
-  servicecode: e2e-service-consumer
+  servicecode: e2e-service-consumer|namespace
   serviceinstancename: consumer1
   starttime: {{ gt .starttime 0 }}
   endtime: {{ gt .endtime 0 }}
@@ -46,7 +46,7 @@ spans:
   spanid: {{ .spanid }}
   parentspanid: {{ .parentspanid }}
   refs: []
-  servicecode: e2e-service-consumer
+  servicecode: e2e-service-consumer|namespace
   serviceinstancename: consumer1
   starttime: {{ gt .starttime 0 }}
   endtime: {{ gt .endtime 0 }}

--- a/tests/e2e/case/grpc/e2e.yaml
+++ b/tests/e2e/case/grpc/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml

--- a/tests/e2e/case/grpc/e2e.yaml
+++ b/tests/e2e/case/grpc/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name="e2e-service-consumer|namespace" \
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml

--- a/tests/e2e/case/http/e2e.yaml
+++ b/tests/e2e/case/http/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name="e2e-service-consumer|namespace"\
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml

--- a/tests/e2e/case/http/e2e.yaml
+++ b/tests/e2e/case/http/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml

--- a/tests/e2e/case/kafka/e2e.yaml
+++ b/tests/e2e/case/kafka/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name="e2e-service-consumer|namespace"\
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml

--- a/tests/e2e/case/kafka/e2e.yaml
+++ b/tests/e2e/case/kafka/e2e.yaml
@@ -72,7 +72,7 @@ verify:
     # trace detail
     - query: |
         swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $( \
-          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer\
+          swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls --service-name=e2e-service-consumer|namespace\
             | yq e '.traces | select(.[].endpointnames[0]=="/artist") | .[0].traceids[0]' -
         )
       expected: ../expected/trace-artist-detail.yml


### PR DESCRIPTION
This PR fixes the first part of issue #[1031](https://github.com/apache/skywalking/issues/10317), adding a suffix namespace separated by `|`.

Also optimized the makefile target order to let the poetry install work better.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue url. Closes: <URL to main repo issue>
- [x] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
