### PR TITLE
Don't init profile / meter damon threads when not active.

### DIFF
--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -259,8 +259,10 @@ class SkyWalkingAgent(Singleton):
             import grpc.experimental.gevent as grpc_gevent
             grpc_gevent.init_gevent()
 
-        profile.init()
-        meter.init(force=True)  # force re-init after fork()
+        if config.agent_profile_active:
+            profile.init()
+        if config.agent_meter_reporter_active:
+            meter.init(force=True)  # force re-init after fork()
 
         self.__bootstrap()  # calls init_threading
 

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -149,7 +149,7 @@ class SpanContext:
 
         parent = self.peek()
         # start profiling if profile_context is set
-        if self.profile_status is None:
+        if config.agent_profile_active and self.profile_status is None:
             self.profile_status = profile.profile_task_execution_service.add_profiling(self,
                                                                                        self.segment.segment_id,
                                                                                        op)
@@ -192,6 +192,8 @@ class SpanContext:
         return span
 
     def profiling_recheck(self, span: Span, op_name: str):
+        if not config.agent_profile_active:
+            return
         # only check first span, e.g, first opname is correct.
         if span.sid != 0:
             return


### PR DESCRIPTION
Don't init profile / meter damon threads when not active since thread is expensive in python.