### PR TITLE
Don't install loguru when not active

### DIFF
--- a/skywalking/plugins/sw_loguru.py
+++ b/skywalking/plugins/sw_loguru.py
@@ -40,6 +40,11 @@ note = """"""
 
 
 def install():
+    
+    if not config.agent_log_reporter_active:
+        # DO NOT even try to monkey-patch if not active, avoid any performance losing.
+        return
+
     from loguru import logger
     from loguru._recattrs import RecordException, RecordFile, RecordLevel, RecordProcess, RecordThread
     from loguru._datetime import aware_now

--- a/skywalking/plugins/sw_loguru.py
+++ b/skywalking/plugins/sw_loguru.py
@@ -40,9 +40,7 @@ note = """"""
 
 
 def install():
-    
     if not config.agent_log_reporter_active:
-        # DO NOT even try to monkey-patch if not active, avoid any performance losing.
         return
 
     from loguru import logger


### PR DESCRIPTION
As a log reporter, it should not be activated when user don't want (agent.archive_log will fail). 

maybe sw_loguru should be treated as sw_logging which is installed before other normal plugins in agent.start(),  
or re-factor sw_loguru & sw_logging into a "log reporter" plugins instead of default "trace reporter" plugins?