### PR TITLE
Fix sw8 loss when use aiohttp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Feature:
   - Add a new workflow to push docker images for arm64 and amd64
 
+- Fixes:
+  - Fix sw8 loss when use aiohttp.(#299,issue#10669)
+
 ### 1.0.0
 
 - **Important Note and Breaking Changes:**
@@ -53,7 +56,6 @@
   - Add namespace suffix to service name (#275)
   - Add periodical instance property report to prevent data loss (#279)
   - Fix sw_logging when `Logger.disabled` is true (#281)
-  - Fix sw8 loss when use aiohttp.(#299,issue#10669)
 
 - Docs:
   - New documentation on how to test locally (#222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
   - Add namespace suffix to service name (#275)
   - Add periodical instance property report to prevent data loss (#279)
   - Fix sw_logging when `Logger.disabled` is true (#281)
+  - Fix sw8 loss when use aiohttp.(#299,issue#10669)
 
 - Docs:
   - New documentation on how to test locally (#222)

--- a/skywalking/plugins/sw_aiohttp.py
+++ b/skywalking/plugins/sw_aiohttp.py
@@ -55,6 +55,7 @@ def install():
                 headers = kwargs['headers'] = CIMultiDict()
             elif not isinstance(headers, (MultiDictProxy, MultiDict)):
                 headers = CIMultiDict(headers)
+                kwargs['headers'] = headers
 
             for item in carrier:
                 headers.add(item.key, item.val)


### PR DESCRIPTION
Fix sw8 loss when use aiohttp.
In /plugins/sw_aiohttp.py
When headers is not MultiDictProxy or MultiDict , headers = CIMultiDict(headers) make the headers not the same object as kwargs['headers'] . Therefore, the carrier information is not added to the actual sent headers
```python
if headers is None:
    headers = kwargs['headers'] = CIMultiDict()
elif not isinstance(headers, (MultiDictProxy, MultiDict)):
    headers = CIMultiDict(headers)
    kwargs['headers'] = headers     # add this line to add headers back.
for item in carrier:
    headers.add(item.key, item.val)
```
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix <bug description or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.


<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
- [ ] I have rebuilt the `Configuration.md` documentation by running `make doc-gen`
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

<!-- ==== 📱 Remove this line WHEN AND ONLY WHEN you're adding or modifying a plugin instrumentation, follow the checklist 👇 ====
### <Feature description>
- [ ] If adding a new plugin, add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ]  If adding a new plugin, add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] I have added the library to `pyproject.toml` (plugin group) by running `poetry add library --group plugins`
- [ ] I have rebuilt the `Plugins.md` documentation by running `make doc-gen`
     ==== 📱 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue url. Closes:[ [<URL to main repo issue>](https://github.com/apache/skywalking/issues/10669)](https://github.com/apache/skywalking/issues/10669)
- [x] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
