### PR TITLE
Fix high CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Fixes:
   - Fix sw8 loss when use aiohttp.(#299,issue#10669)
+  - Fix the bug with high cpu usage.(#300,issue#10672)
 
 ### 1.0.0
 

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -314,7 +314,7 @@ class SkyWalkingAgent(Singleton):
 
     @report_with_backoff(reporter_name='segment', init_wait=0.02)
     def __report_segment(self) -> bool:
-        '''Returns True if the queue is not empty'''
+        """Returns True if the queue is not empty"""
         queue_not_empty_flag = not self.__segment_queue.empty()
         if queue_not_empty_flag:
             self.__protocol.report_segment(self.__segment_queue)
@@ -322,7 +322,7 @@ class SkyWalkingAgent(Singleton):
 
     @report_with_backoff(reporter_name='log', init_wait=0.02)
     def __report_log(self) -> bool:
-        '''Returns True if the queue is not empty'''
+        """Returns True if the queue is not empty"""
         queue_not_empty_flag = not self.__log_queue.empty()
         if queue_not_empty_flag:
             self.__protocol.report_log(self.__log_queue)

--- a/skywalking/agent/__init__.py
+++ b/skywalking/agent/__init__.py
@@ -54,7 +54,7 @@ def report_with_backoff(reporter_name, init_wait):
                     flag = func(self, *args, **kwargs)
                     # for segment/log reporter, if the queue not empty(return True), we should keep reporter working
                     # for other cases(return false or None), reset to base wait time on success
-                    wait = 0 if flag else base 
+                    wait = 0 if flag else base
                 except Exception:  # noqa
                     wait = min(60, wait * 2 or 1)  # double wait time with each consecutive error up to a maximum
                     logger.exception(f'Exception in {reporter_name} service in pid {os.getpid()}, '


### PR DESCRIPTION
About high CPU usage bug discussed in [issues#10672](https://github.com/apache/skywalking/issues/10672), my final solution was to set the `init_wait` parameter in the function decorator to 0.02 (20 ms). In addition, I also made additional changes to make the thread delay more reasonable and closer to the implementation of Java agent.

For the segment/log reporting function, I added a return value of bool type, which is only used by the `@report_with_backoff` decorator to determine whether the queue is not empty. If the queue is not empty, the thread will report the data immediately without any waiting; otherwise, the thread will wait for 20ms to release the CPU usage.

For other types of reporting functions, since their return value is always None, the function decorator still operates according to the original logic

I think the above changes balance the two solutions proposed by [issues#10672](https://github.com/apache/skywalking/issues/10672) and make it more similar to the Java agent implementation

### Fix <bug description or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue url. Closes: [issues#10672](https://github.com/apache/skywalking/issues/10672)
- [x] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
