### PR TITLE
Fix unexpected 'No active span' IllegalStateError

### DIFF
--- a/skywalking/log/sw_logging.py
+++ b/skywalking/log/sw_logging.py
@@ -83,7 +83,7 @@ def install():
             # exceptions before any span is even created, just ignore these fields and
             # avoid appending 'no active span' traceback that could be confusing.
             # Or simply the log is generated outside any span context.
-            active_span_id = context.active_span.sid
+            active_span_id = context.peek(raise_if_none=True).sid
             primary_endpoint_name = context.primary_endpoint.get_name()
         except IllegalStateError:
             pass

--- a/skywalking/plugins/sw_loguru.py
+++ b/skywalking/plugins/sw_loguru.py
@@ -79,7 +79,7 @@ def install():
             # exceptions before any span is even created, just ignore these fields and
             # avoid appending 'no active span' traceback that could be confusing.
             # Or simply the log is generated outside any span context.
-            active_span_id = context.active_span.sid
+            active_span_id = context.peek(raise_if_none=True).sid
             primary_endpoint_name = context.primary_endpoint.get_name()
         except IllegalStateError:
             pass

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -227,16 +227,18 @@ class SpanContext:
         return False
 
     @staticmethod
-    def peek() -> Optional[Span]:
+    def peek(raise_if_none: bool = False) -> Optional[Span]:
         spans = _spans()
-        return spans[-1] if spans else None
+        if not spans:
+            if raise_if_none:
+                raise IllegalStateError('No active span')
+            else:
+                return None
+        return spans[-1]
 
     @property
     def active_span(self):
-        active_span = self.peek()
-        if not active_span:
-            raise IllegalStateError('No active span')
-        return active_span
+        return self.peek(raise_if_none=False)
 
     def get_correlation(self, key):
         if key in self._correlation:


### PR DESCRIPTION
The _skywalking.trace.context.SpanContext.active_span()_ method has been refactored in v1.0.0. Its equivalent method has been changed to _peek()_ . When _peek()_ returns None, the _active_span()_ method throws **IllegalStateError** exception directly. 

This change is not backward compatible, SOME plugins that rely on the returned None value of _active_span()_ WILL be broken ( sw_flask, sw_sanic, sw_tornado, sw_django, etc.).

For example, when running Flask by **gunicorn** which not monkey-patched as well as for sw_http_server plugin, calling _get_context().active_span_ in __sw_handle_exception()_ will raise an IllegalStateError exception directly and break the original logic of the container's _handle_exception()_ .

In v0.8.0, no exception was thrown, so the caller could check if entry_span is not None and perform further processing. 

Therefore, I suggest retaining the behavioral pattern of the _active_span()_ method in v0.8.0 , and providing parameters in the added _peek()_ method to support scenarios where exceptions need to be thrown (such as in sw_logging / sw_loguru).

<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

- [ ] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
