### PR TITLE
Replace Kafka CI image tags to sha

### DIFF
--- a/tests/e2e/base/docker-compose.base.yml
+++ b/tests/e2e/base/docker-compose.base.yml
@@ -119,7 +119,7 @@ services:
     command: [ "run", "python3", "flask_consumer.py" ]
 
   broker-a:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka:3.5.1-debian-11-r3
     hostname: broker-a
     expose:
       - 9092
@@ -138,7 +138,7 @@ services:
       retries: 120
 
   broker-b:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka:3.5.1-debian-11-r3
     hostname: broker-b
     expose:
       - 9092

--- a/tests/e2e/base/docker-compose.base.yml
+++ b/tests/e2e/base/docker-compose.base.yml
@@ -118,8 +118,9 @@ services:
       retries: 120
     command: [ "run", "python3", "flask_consumer.py" ]
 
+  # Using bitnami/kafka:3.5.1-debian-11-r3 image
   broker-a:
-    image: docker.io/bitnami/kafka:3.5.1-debian-11-r3
+    image: docker.io/bitnami/kafka:3.4
     hostname: broker-a
     expose:
       - 9092
@@ -137,8 +138,9 @@ services:
       timeout: 60s
       retries: 120
 
+  # Using bitnami/kafka:3.5.1-debian-11-r3 image
   broker-b:
-    image: docker.io/bitnami/kafka:3.5.1-debian-11-r3
+    image: docker.io/bitnami/kafka:3.4
     hostname: broker-b
     expose:
       - 9092

--- a/tests/e2e/base/docker-compose.base.yml
+++ b/tests/e2e/base/docker-compose.base.yml
@@ -120,7 +120,7 @@ services:
 
   # Using bitnami/kafka:3.5.1-debian-11-r3 image
   broker-a:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka@sha256:e28e91f169403cf56ec04622ff0a8d7b2f0713717cedf3313dd5ab9d3189d0da
     hostname: broker-a
     expose:
       - 9092
@@ -140,7 +140,7 @@ services:
 
   # Using bitnami/kafka:3.5.1-debian-11-r3 image
   broker-b:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka@sha256:e28e91f169403cf56ec04622ff0a8d7b2f0713717cedf3313dd5ab9d3189d0da
     hostname: broker-b
     expose:
       - 9092


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
- [ ] I have rebuilt the `Configuration.md` documentation by running `make doc-gen`
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

<!-- ==== 📱 Remove this line WHEN AND ONLY WHEN you're adding or modifying a plugin instrumentation, follow the checklist 👇 ====
### <Feature description>
- [ ] If adding a new plugin, add a component id in [the main repo](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ]  If adding a new plugin, add a logo in [the UI repo](https://github.com/apache/skywalking-booster-ui/tree/main/src/assets/img/technologies)
- [ ] I have added the library to `pyproject.toml` (plugin group) by running `poetry add library --group plugins`
- [ ] I have rebuilt the `Plugins.md` documentation by running `make doc-gen`
     ==== 📱 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

Currently, Kafka's e2e tests always fail. The reason is that the `bitnami/kafka` images keep introducing non-backwards compatible changes within the same image tag. 

In the latest version, the `bitnami/kafka` image must be configured with some environment variables to select either kraft or zookeeper. In the previous image, no configuration is required, and kraft is used by default. See [bitnami notable changes](https://github.com/bitnami/containers/blob/main/bitnami/kafka/README.md#351-debian-11-r4-341-debian-11-r50-332-debian-11-r176-and-323-debian-11-r161).

To prevent any non-backwards compatible changes from affecting the stability of our CI tests, this PR replaces image tags with sha. The image sha used is [bitnami/kafka:3.5.1-debian-11-r3](https://hub.docker.com/layers/bitnami/kafka/3.5.1-debian-11-r3/images/sha256-e28e91f169403cf56ec04622ff0a8d7b2f0713717cedf3313dd5ab9d3189d0da?context=explore)

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue url. Closes: <URL to main repo issue>
- [ ] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
