### PR TITLE
Fix unexpected 'decode' AttributeError when MySQLdb module is mapped by PyMySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Fix unexpected 'No active span' IllegalStateError (#311)
   - **Tentative**: Set upper bound <=5.9.5 for psutil package due to test failure. (#326)
   - Remove `DeprecationWarning` from `pkg_resources` by replace it with `importlib_metadata` (#329)
+  - Fix unexpected 'decode' AttributeError when MySQLdb module is mapped by PyMySQL (#336)
 
 ### 1.0.1
 

--- a/skywalking/plugins/sw_mysqlclient.py
+++ b/skywalking/plugins/sw_mysqlclient.py
@@ -32,8 +32,8 @@ def install():
     import wrapt
     import MySQLdb
 
-    if hasattr(MySQLdb, "install_as_MySQLdb"):
-        raise ImportError("SKIP fake MySQLdb module mapped by PyMySQL", name="MySQLdb", path="")
+    if hasattr(MySQLdb, 'install_as_MySQLdb'):
+        raise ImportError('SKIP MySQLdb module mapped by PyMySQL', name='MySQLdb', path='')
 
     _connect = MySQLdb.connect
 

--- a/skywalking/plugins/sw_mysqlclient.py
+++ b/skywalking/plugins/sw_mysqlclient.py
@@ -32,6 +32,9 @@ def install():
     import wrapt
     import MySQLdb
 
+    if hasattr(MySQLdb, "install_as_MySQLdb"):
+        raise ImportError("SKIP fake MySQLdb module mapped by PyMySQL", name="MySQLdb", path="")
+
     _connect = MySQLdb.connect
 
     def _sw_connect(*args, **kwargs):


### PR DESCRIPTION
In some use cases, `pymysql.install_as_MySQLdb()` will be used to initialize a 'fake' MySQLdb module, which is actually mapped to pymysql module.

Unfortunately, sw_mysqlclient plugin changes the data type of `connection.db` from `bytes` into `str`,  which is regard as `bytes` in sw_pymysql plugin. That will cause the `AttributeError: 'str' object has no attribute 'decode'` exception in sw_pymysql.py line 45.

So if the `MySQLdb` module  is only a pointer to `pymysql`, we should just raise ImportError instead of installation for sw_mysqlclient plugin.

- [x] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
