### PR TITLE
fix(agent): no attribute '_SkyWalkingAgent__log_queue' using kafka plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - **Tentative**: Set upper bound <=5.9.5 for psutil package due to test failure. (#326)
   - Remove `DeprecationWarning` from `pkg_resources` by replace it with `importlib_metadata` (#329)
   - Fix unexpected 'decode' AttributeError when MySQLdb module is mapped by PyMySQL (#336)
+  - Fix SkyWalking agent failed to start if using kafka protocol with sasl_mechanism=PLAIN. (#343, issue#12131)
+
 
 ### 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
   - **Tentative**: Set upper bound <=5.9.5 for psutil package due to test failure. (#326)
   - Remove `DeprecationWarning` from `pkg_resources` by replace it with `importlib_metadata` (#329)
   - Fix unexpected 'decode' AttributeError when MySQLdb module is mapped by PyMySQL (#336)
-  - Fix SkyWalking agent failed to start if using kafka protocol with sasl_mechanism=PLAIN. (#343, issue#12131)
-
+  - Fix SkyWalking agent failed to start if using kafka protocol with sasl_mechanism=PLAIN. (#343)
 
 ### 1.0.1
 

--- a/docs/en/setup/advanced/LogReporter.md
+++ b/docs/en/setup/advanced/LogReporter.md
@@ -9,7 +9,7 @@ Log reporter supports all three protocols including `grpc`, `http` and `kafka`, 
 If chosen `http` protocol, the logs will be batch-reported to the collector REST endpoint `oap/v3/logs`.
 
 If chosen `kafka` protocol, please make sure to config 
-[kafka-fetcher](https://skywalking.apache.org/docs/main/v9.1.0/en/setup/backend/kafka-fetcher/) 
+[kafka-fetcher](https://skywalking.apache.org/docs/main/v10.0.1/en/setup/backend/kafka-fetcher/) 
 on the OAP side, and make sure Python agent config `kafka_bootstrap_servers` points to your Kafka brokers.
 
 **Please make sure OAP is consuming the same Kafka topic as your agent produces to, `kafka_namespace` must match OAP side configuration `plugin.kafka.namespace`**


### PR DESCRIPTION
- [x] Explain briefly why the bug exists and how to fix it: init queues before init kafka producer
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue url. Closes: [#12131](https://github.com/apache/skywalking/issues/12131)
- [x] Update the [`CHANGELOG.md`](https://github.com/apache/skywalking-python/blob/master/CHANGELOG.md).
