### PR TITLE
Fix: user/password replacement is not allowed for relative urls

### DIFF
--- a/skywalking/plugins/sw_aiohttp.py
+++ b/skywalking/plugins/sw_aiohttp.py
@@ -40,7 +40,8 @@ def install():
     _request = ClientSession._request
 
     async def _sw_request(self: ClientSession, method: str, str_or_url, **kwargs):
-        url = URL(str_or_url).with_user(None).with_password(None)
+        abs_url = self._build_url(str_or_url) if hasattr(self, '_build_url') else URL(str_or_url)
+        url = abs_url.with_user(None).with_password(None)
         peer = f"{url.host or ''}:{url.port or ''}"
 
         if config.agent_protocol == 'http' and config.agent_collector_backend_services.rstrip('/') \


### PR DESCRIPTION
### Fix user/password replacement is not allowed for relative urls

When using the parameter base_url of [ClientSession](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession) constructor, `with_user` and `with_passwrod` at [here](https://github.com/apache/skywalking-python/blob/28602aec01a7f5434c7fe1bd73338cd4478e0761/skywalking/plugins/sw_aiohttp.py#L43) will raise error. 

sample code 

```python
app = Flask(__name__)


@app.get("/cat")
async def application():
    try:
        await aiohttp_demo()
        return {"Cat Fun Fact": "Fact is cat, cat is fat"}
    except Exception as e: 
        return {"message": str(e)}

async def aiohttp_demo():
    async with aiohttp.ClientSession('http://httpbin.org') as session:
        async with session.get('/get'):
            pass
        async with session.post('/post', data=b'data'):
            pass
        async with session.put('/put', data=b'data'):
            pass
```

Since relative URL is used in `session.get('/get')`,  `_sw_request` receives the relative URL as  argument `str_or_url`, then `URL(str_or_url)` will be a relative URL. But `with_user` and `with `with_password` raises `ValueError` when URL is not absolute.

`with_user` for example:

```python
def with_user(self, user):
        val = self._val
        if user is None:
            password = None
        elif isinstance(user, str):
            user = self._QUOTER(user)
            password = val.password
        else:
            raise TypeError("Invalid user type")

        # ================== HERE ===================
        if not self.is_absolute():
            raise ValueError("user replacement is not allowed for relative URLs")
        # ================== HERE ===================
        return URL(
            self._val._replace(
                netloc=self._make_netloc(user, password, val.hostname, val.port)
            ),
            encoded=True,
        )
```

This PR fix it by replacing the URL with a absolute one.
