### PR TITLE
Fix pulsar client not support init arguments other than service_url

### DIFF
--- a/skywalking/plugins/sw_pulsar.py
+++ b/skywalking/plugins/sw_pulsar.py
@@ -45,8 +45,8 @@ def install():
         nonlocal _peer
         _peer = value
 
-    def _sw_init(self, service_url):
-        __init(self, service_url)
+    def _sw_init(self, service_url, *args, **kwargs):
+        __init(self, service_url, *args, **kwargs)
         set_peer(service_url)
 
     def _sw_send_func(_send):

--- a/tests/plugin/data/sw_pulsar/services/consumer.py
+++ b/tests/plugin/data/sw_pulsar/services/consumer.py
@@ -18,7 +18,22 @@
 if __name__ == '__main__':
     import pulsar
 
-    client = pulsar.Client(service_url='pulsar://pulsar-server:6650')
+    client = pulsar.Client(
+        service_url='pulsar://pulsar-server:6650',
+        authentication=None,
+        operation_timeout_seconds=30,
+        io_threads=1,
+        message_listener_threads=1,
+        concurrent_lookup_requests=50000,
+        log_conf_file_path=None,
+        use_tls=False,
+        tls_trust_certs_file_path=None,
+        tls_allow_insecure_connection=False,
+        tls_validate_hostname=False,
+        logger=None,
+        connection_timeout_ms=10000,
+        listener_name=None
+    )
     consumer = client.subscribe('sw-topic', 'sw-subscription')
 
     while True:

--- a/tests/plugin/data/sw_pulsar/services/producer.py
+++ b/tests/plugin/data/sw_pulsar/services/producer.py
@@ -22,7 +22,22 @@ if __name__ == '__main__':
     from pulsar import BatchingType
 
     app = Flask(__name__)
-    client = pulsar.Client(service_url='pulsar://pulsar-server:6650')
+    client = pulsar.Client(
+        service_url='pulsar://pulsar-server:6650',
+        authentication=None,
+        operation_timeout_seconds=30,
+        io_threads=1,
+        message_listener_threads=1,
+        concurrent_lookup_requests=50000,
+        log_conf_file_path=None,
+        use_tls=False,
+        tls_trust_certs_file_path=None,
+        tls_allow_insecure_connection=False,
+        tls_validate_hostname=False,
+        logger=None,
+        connection_timeout_ms=10000,
+        listener_name=None
+    )
     producer = client.create_producer(
         'sw-topic',
         block_if_queue_full=True,


### PR DESCRIPTION
### Fix pulsar client not support init arguments other than service_ur
- [x] Updated the sw_pulsar unit test to verify that the fix works.
- [x] Added *args and **kwargs to sw_pular `sw_init`, making it work with arguments other than service_url 