### PR TITLE
Fix agent start failed in async mode when profiling is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Fix pulsar client does not support init arguments other than service_url (#351)
   - Fix outdated make dev-fix rule in CodeStyle.md (#350)
   - Fix TestClient for fastapi cause the req.client None error (#355)
+  - Fix agent start failed in async mode when profiling is enabled (#360)
 
 ### 1.1.0
 

--- a/skywalking/command/command_service.py
+++ b/skywalking/command/command_service.py
@@ -68,11 +68,11 @@ class CommandService:
 class CommandServiceAsync:
 
     def __init__(self):
-        self._commands = AsyncQueue()  # type: AsyncQueue
         # don't execute same command twice
         self._command_serial_number_cache = CommandSerialNumberCache()
 
     async def dispatch(self):
+        self._commands = AsyncQueue()  # type: AsyncQueue
         while True:
             # block until a command is available
             command = await self._commands.get()  # type: BaseCommand


### PR DESCRIPTION
### Fix agent start failed in async mode when profiling is enabled

`CommandServiceAsync` instance is created in the initial event loop, so as its `_command` async queue. But `CommandServiceAsync.dispatch` is called from the event loop created by `SkyWalkingAgentAsync.__start_event_loop`. Async queue is bound with a event loop, leading to the error below when agent starts.

```
2024-11-07 18:34:05,573 skywalking [pid:415062] [event_loop_thread] [ERROR] Error in Python agent asyncio event
 loop: Task <Task pending name='Task-9' coro=<SkyWalkingAgentAsync.__command_dispatch() running at 
/home/netease/.cache/pypoetry/virtualenvs/sw-flask-stage-demo-I8S3EFWq-py3.9/lib/python3.9/site-
packages/skywalking/agent/__init__.py:653> cb=[_gather.<locals>._done_callback() at 
/home/netease/.pyenv/versions/3.9.20/lib/python3.9/asyncio/tasks.py:767]> got Future <Future pending> attached to a 
different loop
```