### PR TITLE
Perf ignore uuid and timestamp generation for NoopContext

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -13,7 +13,7 @@
 
 <!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
 ### Improve the performance of <class or module or ...>
-- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
+- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking/blob/master/oap-server/microbench/src/main/java/org/apache/skywalking/oap/server/microbench/library/datacarrier/LinkedArrayBenchmark.java)
 - [ ] The benchmark result.
 ```text
 <Paste the benchmark results here>

--- a/poetry.lock
+++ b/poetry.lock
@@ -2564,6 +2564,17 @@ avro = ["fastavro (==1.7.3)"]
 functions = ["apache-bookkeeper-client (>=4.16.1)", "grpcio (>=1.8.2)", "prometheus-client", "protobuf (>=3.6.1,<=3.20.3)", "ratelimit"]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -2874,6 +2885,26 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-benchmark"
+version = "4.0.0"
+description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
+    {file = "pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6"},
+]
+
+[package.dependencies]
+py-cpuinfo = "*"
+pytest = ">=3.8"
+
+[package.extras]
+aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "pytz"
@@ -3937,4 +3968,4 @@ sync = ["kafka-python", "requests"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.12"
-content-hash = "0b095f92380b765e30f77c53577a2b42c7b8917945885ccb9d597040134520db"
+content-hash = "957ba196be529a7924617a968a810a5934461cb43936ed738779123e963fcb63"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ gunicorn = "*"
 uvicorn = "*"
 kafka-python = "*"
 requests = "*"
+pytest-benchmark = "4.0.0"
 
 [tool.poetry.group.plugins.dependencies]
 urllib3 = "1.26.7"

--- a/skywalking/trace/context.py
+++ b/skywalking/trace/context.py
@@ -23,7 +23,7 @@ from skywalking.profile.profile_status import ProfileStatusReference
 from skywalking import sampling
 from skywalking.trace import ID
 from skywalking.trace.carrier import Carrier
-from skywalking.trace.segment import Segment, SegmentRef
+from skywalking.trace.segment import NoopSegment, Segment, SegmentRef
 from skywalking.trace.snapshot import Snapshot
 from skywalking.trace.span import Span, Kind, NoopSpan, EntrySpan, ExitSpan
 from skywalking.utils.counter import Counter
@@ -95,7 +95,7 @@ class PrimaryEndpoint:
 
 class SpanContext:
     def __init__(self):
-        self.segment: Segment = Segment()
+        self.segment = Segment()
         self._sid: Counter = Counter()
         self._correlation: dict = {}
         self._nspans: int = 0
@@ -285,7 +285,13 @@ class SpanContext:
 
 class NoopContext(SpanContext):
     def __init__(self):
-        super().__init__()
+        self.segment = NoopSegment()
+        self._sid: Counter = Counter()
+        self._correlation: dict = {}
+        self._nspans: int = 0
+        self.profile_status: Optional[ProfileStatusReference] = None
+        self.create_time = 0
+        self.primary_endpoint: Optional[PrimaryEndpoint] = None
 
     def new_local_span(self, op: str) -> Span:
         return NoopSpan(self)

--- a/skywalking/trace/segment.py
+++ b/skywalking/trace/segment.py
@@ -68,6 +68,12 @@ class _NewID(ID):
     pass
 
 
+class _NewNoopID(ID):
+
+    def __init__(self):
+        self.value = ''
+
+
 @tostring
 class Segment(object):
     def __init__(self):
@@ -83,3 +89,11 @@ class Segment(object):
         if isinstance(self.related_traces[0], _NewID):
             del self.related_traces[-1]
         self.related_traces.append(trace_id)
+
+
+class NoopSegment(Segment):
+    def __init__(self):
+        self.segment_id = _NewNoopID()
+        self.spans = []
+        self.timestamp = 0
+        self.related_traces = [_NewNoopID()]

--- a/tests/benchmark/__init__.py
+++ b/tests/benchmark/__init__.py
@@ -14,18 +14,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from typing import Optional
-import uuid
-
-from skywalking.utils.counter import AtomicCounter
-
-_id = AtomicCounter()
-
-
-class ID(object):
-    def __init__(self, raw_id: Optional[str] = None):
-        self.value = raw_id or str(uuid.uuid1()).replace('-', '')
-
-    def __str__(self):
-        return self.value

--- a/tests/benchmark/test_span.py
+++ b/tests/benchmark/test_span.py
@@ -15,17 +15,22 @@
 # limitations under the License.
 #
 
-from typing import Optional
-import uuid
-
-from skywalking.utils.counter import AtomicCounter
-
-_id = AtomicCounter()
+from typing import Any
+from skywalking.trace.context import NoopContext
+from skywalking.trace.span import NoopSpan
 
 
-class ID(object):
-    def __init__(self, raw_id: Optional[str] = None):
-        self.value = raw_id or str(uuid.uuid1()).replace('-', '')
+def test_noopspan_1000(benchmark: Any):
+    result = benchmark(lambda: [NoopSpan(NoopContext()) for _ in range(1000)])
+    assert result
 
-    def __str__(self):
-        return self.value
+
+def test_noopspan_40000(benchmark: Any):
+    result = benchmark(lambda: [NoopSpan(NoopContext()) for _ in range(40000)])
+    assert result
+
+
+def test_noopspan_200k(benchmark: Any):
+    result = benchmark(
+        lambda: [NoopSpan(NoopContext()) for _ in range(200000)])
+    assert result


### PR DESCRIPTION
### Improve the performance of NoopSpan
- [x] Add a benchmark for the improvement
- [x] The benchmark result.

Before
```text
----------------------------------------------------------------------------------------- benchmark: 3 tests -----------------------------------------------------------------------------------------
Name (time in ms)              Min                   Max                  Mean             StdDev                Median                 IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_noopspan_1000         16.3042 (1.0)         23.7947 (1.0)         17.9170 (1.0)       1.9692 (1.0)         17.2309 (1.0)        1.0547 (1.0)           7;7  55.8130 (1.0)          39           1
test_noopspan_40000       869.6260 (53.34)      924.5368 (38.85)      901.9029 (50.34)    24.5816 (12.48)      916.3565 (53.18)     40.6119 (38.50)         1;0   1.1088 (0.02)          5           1
test_noopspan_200k      4,691.7849 (287.77)   4,847.9470 (203.74)   4,778.1474 (266.68)   67.2721 (34.16)    4,791.8445 (278.10)   118.2709 (112.13)        2;0   0.2093 (0.00)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
After
```text
------------------------------------------------------------------------------------------ benchmark: 3 tests ------------------------------------------------------------------------------------------
Name (time in ms)              Min                   Max                  Mean              StdDev                Median                 IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_noopspan_1000          4.1980 (1.0)         10.8732 (1.0)          5.3377 (1.0)        1.7625 (1.0)          4.5595 (1.0)        0.2741 (1.0)         15;15  187.3464 (1.0)          83           1
test_noopspan_40000       407.3876 (97.04)      415.4321 (38.21)      411.5557 (77.10)      2.9544 (1.68)       411.7374 (90.30)      3.6798 (13.43)         2;0    2.4298 (0.01)          5           1
test_noopspan_200k      2,087.1523 (497.18)   2,446.8792 (225.04)   2,259.6033 (423.33)   139.2377 (79.00)    2,274.1380 (498.77)   206.5788 (753.73)        2;0    0.4426 (0.00)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

- [x] Links/URLs to the theory proof or discussion articles/blogs. 

 It seems that uuid and timestamp are useless for a noop span, since it won't be reported for analysis. So remove them to save cpu and time.