### PR TITLE
Fix: kafka image in docker-compose demo

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
   
   kafka:
     container_name: kafka
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:7.2.15
     expose:
       - 9092
       - 9094


### PR DESCRIPTION
With the update of the default tag of confluentin/cp-kafka, it is maybe no longer applicable to the current demo.
Use the exact image tag 7.2.15 to ensure that the oap demo can be successfully launched.