### PR TITLE
feat(odoo): add Odoo HTTP instrumentation and fail-open bootstrap

### DIFF
--- a/docs/en/setup/Plugins.md
+++ b/docs/en/setup/Plugins.md
@@ -36,6 +36,7 @@ or a limitation of SkyWalking auto-instrumentation (welcome to contribute!)
 | [loguru](https://pypi.org/project/loguru/) | Python >=3.7 - ['0.6.0', '0.7.0'];  | `sw_loguru` |
 | [mysqlclient](https://mysqlclient.readthedocs.io/) | Python >=3.7 - ['2.1.*'];  | `sw_mysqlclient` |
 | [neo4j](https://neo4j.com/docs/python-manual/5/) | Python >=3.7 - ['5.*'];  | `sw_neo4j` |
+| [odoo](https://www.odoo.com/documentation/13.0/) | Python >=3.10 - ['13.0'];  | `sw_odoo` |
 | [psycopg[binary]](https://www.psycopg.org/) | Python >=3.13 - ['3.2.*']; Python >=3.11 - ['3.1.*']; Python >=3.10 - ['3.0.18', '3.1.*'];  | `sw_psycopg` |
 | [psycopg2-binary](https://www.psycopg.org/) | Python >=3.10 - ['2.9.*'];  | `sw_psycopg2` |
 | [pulsar-client](https://github.com/apache/pulsar-client-python) | Python >=3.12 - ['3.9.0']; Python >=3.10 - ['3.3.0'];  | `sw_pulsar` |
@@ -73,4 +74,3 @@ the actual message exchange (send/recv) is not traced since injecting headers to
 body is the only way to propagate the trace context, which requires customization of message structure
 and extreme care. (Feel free to add this feature by instrumenting the send/recv methods commented out in the code
 by either injecting sw8 headers or propagate the trace context in a separate message)
-

--- a/docs/en/setup/faq/How-to-use-with-odoo.md
+++ b/docs/en/setup/faq/How-to-use-with-odoo.md
@@ -1,0 +1,32 @@
+# How to use with Odoo?
+
+The Odoo integration is intended for Odoo applications that start their own server process, such as an Odoo project
+launched from a `start` script under Docker, Kubernetes, or Supervisor.
+
+Add the SkyWalking Odoo bootstrap before the first `import odoo` in the application entrypoint:
+
+```python
+from skywalking.bootstrap.odoo import maybe_start
+maybe_start()
+
+import odoo
+```
+
+The bootstrap starts the SkyWalking agent only when both environment variables are non-empty:
+
+```shell
+SW_AGENT_NAME=odoo-service
+SW_AGENT_COLLECTOR_BACKEND_SERVICES=http://oap:12800
+```
+
+`SW_AGENT_NAME` is the SkyWalking service name, following the same service naming configuration used by the other
+SkyWalking Python plugins.
+`SW_AGENT_COLLECTOR_BACKEND_SERVICES` is the OAP HTTP collector address. Values with `http://` and `https://`
+prefixes are accepted; `https://` enables TLS for the agent's HTTP reporter. Use the OAP HTTP port, usually `12800`,
+not the gRPC port `11800`.
+
+For Docker or Kubernetes, put the two variables in the container environment. If either variable is absent or empty,
+`maybe_start()` returns without starting the agent and Odoo runs normally.
+
+The bootstrap is fail-open. If the SkyWalking agent fails to start, `maybe_start()` returns `False` and the Odoo
+process can continue without tracing.

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -50,6 +50,8 @@ catalog:
         path: "/en/setup/faq/How-to-use-with-gunicorn"
       - name: "How To Use With uWSGI"
         path: "/en/setup/faq/How-to-use-with-uwsgi"
+      - name: "How To Use With Odoo"
+        path: "/en/setup/faq/How-to-use-with-odoo"
       - name: "How To Disable Plugins"
         path: "/en/setup/faq/How-to-disable-plugin"
       - name: "Performance Best Practices"

--- a/skywalking/__init__.py
+++ b/skywalking/__init__.py
@@ -55,6 +55,7 @@ class Component(Enum):
     AIORedis = 7017
     Websockets = 7018
     HTTPX = 7019
+    Odoo = 7020
     Grpc = 23
 
 

--- a/skywalking/bootstrap/odoo.py
+++ b/skywalking/bootstrap/odoo.py
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from urllib.parse import urlsplit
+
+from skywalking import config
+from skywalking.loggings import logger
+
+
+def maybe_start():
+    agent_name = os.getenv('SW_AGENT_NAME', '').strip()
+    backend = os.getenv('SW_AGENT_COLLECTOR_BACKEND_SERVICES', '').strip()
+    if not agent_name or not backend:
+        return False
+
+    backend, force_tls = _normalize_backend(backend)
+    config.agent_protocol = 'http'
+    config.agent_name = agent_name
+    config.agent_collector_backend_services = backend
+    config.agent_force_tls = force_tls
+    try:
+        _start_agent()
+        return True
+    except Exception:
+        logger.debug('SkyWalking Odoo bootstrap failed, continue without agent.', exc_info=True)
+        return False
+
+
+def _normalize_backend(backend):
+    parsed = urlsplit(backend)
+    if parsed.scheme in ('http', 'https') and parsed.netloc:
+        return parsed.netloc + parsed.path.rstrip('/'), parsed.scheme == 'https'
+
+    return backend.rstrip('/'), False
+
+
+def _start_agent():
+    from skywalking.agent import agent
+    agent.start()

--- a/skywalking/plugins/sw_odoo.py
+++ b/skywalking/plugins/sw_odoo.py
@@ -1,0 +1,175 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from skywalking import Layer, Component, config
+from skywalking.loggings import logger
+from skywalking.trace.carrier import Carrier
+from skywalking.trace.tags import TagHttpMethod, TagHttpURL, TagHttpStatusCode
+
+link_vector = ['https://www.odoo.com/documentation/13.0/']
+support_matrix = {
+    'odoo': {
+        '>=3.10': ['13.0']
+    }
+}
+note = """"""
+
+
+def install():
+    from odoo.http import Root
+
+    if getattr(Root, '_sw_odoo_wrapped', False):
+        return
+
+    _dispatch = Root.dispatch
+
+    def _sw_dispatch(this, environ, start_response):
+        try:
+            method = environ.get('REQUEST_METHOD', '')
+            path = environ.get('PATH_INFO') or '/'
+            carrier = _carrier_from_environ(environ)
+            status_code = [-1]
+
+            def _sw_start_response(status, response_headers, exc_info=None):
+                status_code[0] = _parse_status_code(status)
+                if exc_info is not None:
+                    try:
+                        return start_response(status, response_headers, exc_info)
+                    except TypeError:
+                        return start_response(status, response_headers)
+                return start_response(status, response_headers)
+
+            span = _new_noop_span() if config.ignore_http_method_check(method) \
+                else get_context().new_entry_span(op=path, carrier=carrier, inherit=Component.General)
+        except Exception:
+            _log_tracing_exception('SkyWalking Odoo tracing setup failed, dispatch without tracing.')
+            return _dispatch(this, environ, start_response)
+
+        if not _safe_enter_span(span):
+            return _dispatch(this, environ, start_response)
+
+        exc_info = (None, None, None)
+        try:
+            _safe_prepare_span(span, environ, method, path)
+            try:
+                return _dispatch(this, environ, _sw_start_response)
+            except Exception:
+                import sys
+                exc_info = sys.exc_info()
+                raise
+            finally:
+                _safe_tag_status(span, status_code[0])
+        finally:
+            _safe_exit_span(span, exc_info)
+
+    Root.dispatch = _sw_dispatch
+    Root._sw_odoo_wrapped = True
+
+
+def get_context():
+    from skywalking.trace.context import get_context as _get_context
+    return _get_context()
+
+
+def _safe_enter_span(span):
+    try:
+        span.__enter__()
+        return True
+    except Exception:
+        _log_tracing_exception('SkyWalking Odoo span start failed, dispatch without tracing.')
+        return False
+
+
+def _safe_exit_span(span, exc_info):
+    try:
+        span.__exit__(*exc_info)
+    except Exception:
+        _log_tracing_exception('SkyWalking Odoo span stop failed.')
+
+
+def _safe_prepare_span(span, environ, method, path):
+    try:
+        span.layer = Layer.Http
+        span.component = Component.Odoo
+        span.peer = _peer_from_environ(environ)
+    except Exception:
+        _log_tracing_exception('SkyWalking Odoo span attribute setup failed.')
+
+    _safe_tag(span, lambda: TagHttpMethod(method))
+    _safe_tag(span, lambda: TagHttpURL(_url_from_environ(environ, path)))
+
+
+def _safe_tag_status(span, status_code):
+    if status_code <= -1:
+        return
+
+    _safe_tag(span, lambda: TagHttpStatusCode(status_code))
+    if status_code >= 400:
+        try:
+            span.error_occurred = True
+        except Exception:
+            _log_tracing_exception('SkyWalking Odoo span error flag setup failed.')
+
+
+def _safe_tag(span, tag_factory):
+    try:
+        span.tag(tag_factory())
+    except Exception:
+        _log_tracing_exception('SkyWalking Odoo span tag setup failed.')
+
+
+def _log_tracing_exception(message):
+    try:
+        logger.debug(message, exc_info=True)
+    except Exception:
+        pass
+
+
+def _new_noop_span():
+    from skywalking.trace.context import NoopContext
+    from skywalking.trace.span import NoopSpan
+    return NoopSpan(NoopContext())
+
+
+def _carrier_from_environ(environ):
+    carrier = Carrier()
+    for item in carrier:
+        key = 'HTTP_' + item.key.upper().replace('-', '_')
+        if key in environ:
+            item.val = environ[key]
+    if carrier.is_suppressed:
+        return Carrier(correlation=carrier.correlation_carrier.correlation)
+    return carrier
+
+
+def _peer_from_environ(environ):
+    remote_addr = environ.get('REMOTE_ADDR')
+    remote_port = environ.get('REMOTE_PORT') or '80'
+    return f'{remote_addr}:{remote_port}' if remote_addr else ''
+
+
+def _url_from_environ(environ, path):
+    scheme = environ.get('wsgi.url_scheme') or 'http'
+    host = environ.get('HTTP_HOST') or environ.get('SERVER_NAME') or ''
+    return f'{scheme}://{host}{path}' if host else path
+
+
+def _parse_status_code(status):
+    try:
+        return int(str(status).split(' ', 1)[0])
+    except (TypeError, ValueError):
+        return -1

--- a/skywalking/plugins/sw_websockets.py
+++ b/skywalking/plugins/sw_websockets.py
@@ -28,8 +28,7 @@ note = """The websocket instrumentation only traces client side connection hands
 the actual message exchange (send/recv) is not traced since injecting headers to socket message
 body is the only way to propagate the trace context, which requires customization of message structure
 and extreme care. (Feel free to add this feature by instrumenting the send/recv methods commented out in the code
-by either injecting sw8 headers or propagate the trace context in a separate message)
-"""
+by either injecting sw8 headers or propagate the trace context in a separate message)"""
 
 
 def install():

--- a/tests/unit/test_odoo_bootstrap.py
+++ b/tests/unit/test_odoo_bootstrap.py
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+from skywalking import config
+from skywalking.bootstrap import odoo
+
+
+class TestOdooBootstrap(unittest.TestCase):
+    def setUp(self):
+        self.environ = os.environ.copy()
+        self.original_protocol = config.agent_protocol
+        self.original_name = config.agent_name
+        self.original_namespace = config.agent_namespace
+        self.original_backend = config.agent_collector_backend_services
+        self.original_tls = config.agent_force_tls
+        self.started = []
+        self.original_start_agent = odoo._start_agent
+        odoo._start_agent = lambda: self.started.append(True)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.environ)
+        config.agent_protocol = self.original_protocol
+        config.agent_name = self.original_name
+        config.agent_namespace = self.original_namespace
+        config.agent_collector_backend_services = self.original_backend
+        config.agent_force_tls = self.original_tls
+        odoo._start_agent = self.original_start_agent
+
+    def test_maybe_start_noops_without_agent_name(self):
+        os.environ.pop('SW_AGENT_NAME', None)
+        os.environ['SW_AGENT_COLLECTOR_BACKEND_SERVICES'] = 'http://oap:12800'
+
+        self.assertFalse(odoo.maybe_start())
+
+        self.assertEqual([], self.started)
+
+    def test_maybe_start_noops_without_backend(self):
+        os.environ['SW_AGENT_NAME'] = 'odoo-service'
+        os.environ.pop('SW_AGENT_COLLECTOR_BACKEND_SERVICES', None)
+
+        self.assertFalse(odoo.maybe_start())
+
+        self.assertEqual([], self.started)
+
+    def test_maybe_start_uses_sw_agent_name_as_service_name(self):
+        os.environ['SW_AGENT_NAME'] = 'odoo-service'
+        os.environ['SW_AGENT_COLLECTOR_BACKEND_SERVICES'] = 'http://oap:12800'
+        config.agent_namespace = 'unexpected-namespace'
+
+        self.assertTrue(odoo.maybe_start())
+
+        self.assertEqual('http', config.agent_protocol)
+        self.assertEqual('odoo-service', config.agent_name)
+        self.assertEqual('unexpected-namespace', config.agent_namespace)
+        self.assertEqual('oap:12800', config.agent_collector_backend_services)
+        self.assertFalse(config.agent_force_tls)
+        self.assertEqual([True], self.started)
+
+    def test_maybe_start_accepts_https_backend(self):
+        os.environ['SW_AGENT_NAME'] = 'odoo-service'
+        os.environ['SW_AGENT_COLLECTOR_BACKEND_SERVICES'] = 'https://oap.example.com:12800'
+
+        self.assertTrue(odoo.maybe_start())
+
+        self.assertEqual('oap.example.com:12800', config.agent_collector_backend_services)
+        self.assertTrue(config.agent_force_tls)
+        self.assertEqual([True], self.started)
+
+    def test_maybe_start_returns_false_when_agent_start_fails(self):
+        os.environ['SW_AGENT_NAME'] = 'odoo-service'
+        os.environ['SW_AGENT_COLLECTOR_BACKEND_SERVICES'] = 'http://oap:12800'
+
+        def fail_start():
+            raise RuntimeError('agent failed')
+
+        odoo._start_agent = fail_start
+
+        self.assertFalse(odoo.maybe_start())
+
+    def test_maybe_start_strips_empty_values(self):
+        os.environ['SW_AGENT_NAME'] = '   '
+        os.environ['SW_AGENT_COLLECTOR_BACKEND_SERVICES'] = ' http://oap:12800 '
+
+        self.assertFalse(odoo.maybe_start())
+
+        self.assertEqual([], self.started)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_odoo_plugin.py
+++ b/tests/unit/test_odoo_plugin.py
@@ -1,0 +1,234 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import types
+import unittest
+
+from skywalking import Component, Layer, config
+from skywalking.plugins import sw_odoo
+
+
+class FakeSpan:
+    def __init__(self, op, carrier):
+        self.op = op
+        self.carrier = carrier
+        self.layer = None
+        self.component = None
+        self.peer = None
+        self.tags = []
+        self.error_occurred = False
+        self.raised_called = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if isinstance(exc_val, Exception):
+            self.raised()
+        return False
+
+    def tag(self, tag):
+        self.tags.append((tag.key, tag.val))
+        return self
+
+    def raised(self):
+        self.raised_called = True
+        self.error_occurred = True
+        return self
+
+
+class FakeContext:
+    def __init__(self):
+        self.spans = []
+
+    def new_entry_span(self, op, carrier=None, inherit=None):
+        span = FakeSpan(op, carrier)
+        self.spans.append(span)
+        return span
+
+
+class FakeRoot:
+    def dispatch(self, environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'ok']
+
+
+class TestOdooPlugin(unittest.TestCase):
+    def setUp(self):
+        self.modules = sys.modules.copy()
+        self.original_ignore = config.RE_HTTP_IGNORE_METHOD
+        self.fake_context = FakeContext()
+        self.original_get_context = sw_odoo.get_context
+        sw_odoo.get_context = lambda: self.fake_context
+
+        odoo_module = types.ModuleType('odoo')
+        http_module = types.ModuleType('odoo.http')
+        http_module.Root = FakeRoot
+        odoo_module.http = http_module
+        sys.modules['odoo'] = odoo_module
+        sys.modules['odoo.http'] = http_module
+
+    def tearDown(self):
+        sys.modules.clear()
+        sys.modules.update(self.modules)
+        config.RE_HTTP_IGNORE_METHOD = self.original_ignore
+        sw_odoo.get_context = self.original_get_context
+
+    def test_dispatch_creates_http_entry_span(self):
+        sw_odoo.install()
+        root = sys.modules['odoo.http'].Root()
+        status = []
+
+        result = root.dispatch({
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': '/web/login',
+            'QUERY_STRING': 'debug=1',
+            'HTTP_HOST': 'odoo.example.com',
+            'REMOTE_ADDR': '10.0.0.5',
+            'REMOTE_PORT': '45678',
+            'HTTP_SW8': 'bad-carrier',
+            'HTTP_SW8_CORRELATION': 'dGVuYW50:ZWM=',
+        }, lambda value, headers, exc_info=None: status.append(value))
+
+        self.assertEqual([b'ok'], result)
+        self.assertEqual(['200 OK'], status)
+        self.assertEqual(1, len(self.fake_context.spans))
+        span = self.fake_context.spans[0]
+        self.assertEqual('/web/login', span.op)
+        self.assertEqual(Layer.Http, span.layer)
+        self.assertEqual(Component.Odoo, span.component)
+        self.assertEqual('10.0.0.5:45678', span.peer)
+        self.assertIn(('http.method', 'GET'), span.tags)
+        self.assertIn(('http.url', 'http://odoo.example.com/web/login'), span.tags)
+        self.assertIn(('http.status_code', '200'), span.tags)
+        self.assertFalse(span.carrier.is_suppressed)
+        self.assertFalse(span.carrier.is_valid)
+        self.assertEqual({'tenant': 'ec'}, span.carrier.correlation_carrier.correlation)
+
+    def test_invalid_sw8_header_does_not_suppress_odoo_entry_span(self):
+        carrier = sw_odoo._carrier_from_environ({
+            'HTTP_SW8': 'bad-carrier',
+            'HTTP_SW8_CORRELATION': 'dGVuYW50:ZWM=',
+        })
+
+        self.assertFalse(carrier.is_suppressed)
+        self.assertFalse(carrier.is_valid)
+        self.assertEqual({'tenant': 'ec'}, carrier.correlation_carrier.correlation)
+
+    def test_dispatch_supports_odoo_two_argument_start_response_wrapper(self):
+        sw_odoo.install()
+        root = sys.modules['odoo.http'].Root()
+        status = []
+
+        result = root.dispatch(
+            {'REQUEST_METHOD': 'GET', 'PATH_INFO': '/web/login'},
+            lambda value, headers: status.append(value),
+        )
+
+        self.assertEqual([b'ok'], result)
+        self.assertEqual(['200 OK'], status)
+
+    def test_dispatch_supports_two_argument_start_response_wrapper_with_exc_info(self):
+        class ExcInfoRoot:
+            def dispatch(self, environ, start_response):
+                start_response('500 Internal Server Error', [], (RuntimeError, RuntimeError('boom'), None))
+                return [b'error']
+
+        sys.modules['odoo.http'].Root = ExcInfoRoot
+        sw_odoo.install()
+        root = sys.modules['odoo.http'].Root()
+        status = []
+
+        result = root.dispatch(
+            {'REQUEST_METHOD': 'GET', 'PATH_INFO': '/web/login'},
+            lambda value, headers: status.append(value),
+        )
+
+        self.assertEqual([b'error'], result)
+        self.assertEqual(['500 Internal Server Error'], status)
+
+    def test_dispatch_falls_back_to_odoo_when_tracing_setup_fails(self):
+        sw_odoo.get_context = lambda: (_ for _ in ()).throw(RuntimeError('trace failed'))
+        sw_odoo.install()
+        root = sys.modules['odoo.http'].Root()
+        status = []
+
+        result = root.dispatch(
+            {'REQUEST_METHOD': 'GET', 'PATH_INFO': '/web/login'},
+            lambda value, headers: status.append(value),
+        )
+
+        self.assertEqual([b'ok'], result)
+        self.assertEqual(['200 OK'], status)
+        self.assertEqual([], self.fake_context.spans)
+
+    def test_dispatch_falls_back_to_odoo_when_span_start_fails(self):
+        class FailingStartSpan(FakeSpan):
+            def __enter__(self):
+                raise RuntimeError('span start failed')
+
+        class FailingStartContext(FakeContext):
+            def new_entry_span(self, op, carrier=None, inherit=None):
+                return FailingStartSpan(op, carrier)
+
+        self.fake_context = FailingStartContext()
+        sw_odoo.install()
+        root = sys.modules['odoo.http'].Root()
+        status = []
+
+        result = root.dispatch(
+            {'REQUEST_METHOD': 'GET', 'PATH_INFO': '/web/login'},
+            lambda value, headers: status.append(value),
+        )
+
+        self.assertEqual([b'ok'], result)
+        self.assertEqual(['200 OK'], status)
+
+    def test_dispatch_marks_http_errors(self):
+        class ErrorRoot:
+            def dispatch(self, environ, start_response):
+                start_response('500 Internal Server Error', [])
+                return [b'error']
+
+        sys.modules['odoo.http'].Root = ErrorRoot
+        sw_odoo.install()
+
+        root = sys.modules['odoo.http'].Root()
+        root.dispatch({'REQUEST_METHOD': 'POST', 'PATH_INFO': '/web/dataset/call_kw'}, lambda *_: None)
+
+        span = self.fake_context.spans[0]
+        self.assertTrue(span.error_occurred)
+        self.assertIn(('http.status_code', '500'), span.tags)
+
+    def test_dispatch_records_exceptions_and_reraises(self):
+        class RaisingRoot:
+            def dispatch(self, environ, start_response):
+                raise RuntimeError('boom')
+
+        sys.modules['odoo.http'].Root = RaisingRoot
+        sw_odoo.install()
+
+        root = sys.modules['odoo.http'].Root()
+        with self.assertRaises(RuntimeError):
+            root.dispatch({'REQUEST_METHOD': 'GET', 'PATH_INFO': '/boom'}, lambda *_: None)
+
+        self.assertTrue(self.fake_context.spans[0].raised_called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Odoo plugin that instruments Root.dispatch to create HTTP entry spans.
- Provide fail-open bootstrap in skywalking.bootstrap.odoo.maybe_start() that starts the agent only when both required env vars are set.
- Add usage docs and unit tests for bootstrap and plugin logic.

## Test Plan
- python -m unittest tests.unit.test_version_check tests.unit.test_odoo_bootstrap tests.unit.test_odoo_plugin -v
- python -m py_compile skywalking/bootstrap/odoo.py skywalking/plugins/sw_odoo.py tests/unit/test_odoo_bootstrap.py tests/unit/test_odoo_plugin.py
- git diff --check HEAD~1..HEAD