### PR TITLE
fix(ci): unblock CI — approved paths-filter pin + happybase test flake

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check for file changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # The following filters indicate a category along with

--- a/tests/plugin/data/sw_happybase/test_happybase.py
+++ b/tests/plugin/data/sw_happybase/test_happybase.py
@@ -27,7 +27,12 @@ from tests.plugin.base import TestPluginBase
 @pytest.fixture
 def prepare():
     # type: () -> Callable
-    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=5)
+    # HBase cold-start `create_table` over Thrift can exceed a few seconds. A short
+    # client timeout makes the readiness loop (conftest) retry while the server has
+    # already created the table, so the retried request hits AlreadyExists -> 500 and
+    # an extra error segment leaks into the collector (breaking segmentSize: 1).
+    # Use a generous timeout so the first reachable request completes cleanly.
+    return lambda *_: requests.get('http://0.0.0.0:9090/users', timeout=60)
 
 
 class TestPlugin(TestPluginBase):


### PR DESCRIPTION
This PR contains two independent fixes, both required to get CI green again. Both regressions were introduced by #386.

---

### 1. Repin `dorny/paths-filter` to the ASF-approved SHA

CI was failing on every run with the ASF GitHub Actions allow-list gateway:

> The action `dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36` is not allowed in apache/skywalking-python …

#386 switched the change-detection step to `dorny/paths-filter@de90cc…` (**v3.0.2**), which is **not** on the [ASF approved patterns list](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml).

**Fix:** repin to `dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d` (**v4.0.1**) — the only approved `dorny/paths-filter` SHA, and the same pin already used by [`apache/skywalking`](https://github.com/apache/skywalking/blob/master/.github/workflows/skywalking.yaml). The action's API (`filters` / `id` / `list-files` / `outputs`) is unchanged between v3 and v4; v4.0.1 only bumps the Node runtime.

---

### 2. Raise the happybase readiness-probe timeout (fixes `Plugin and Unit Tests (3.12, tests/plugin/data)`)

`tests/plugin/data/sw_happybase` was failing on the 3.12 shard with an unexpected extra segment:

```
Hbase_thrift.AlreadyExists: AlreadyExists(message=b'table name already in use')   # http.status_code: 500
```

**Root cause:** the consumer's `GET /users` runs a cold HBase `create_table` over Thrift, which can take longer than the readiness probe's **`timeout=5`**. When it does, `requests` raises `ReadTimeout` and the conftest readiness loop retries — but the server has already created the table. The retried request then hits `AlreadyExists` → HTTP 500 (which `requests` does not raise on), so the loop accepts it and a **second, errored segment** leaks into the collector, breaking the `segmentSize: 1` assertion.

Consumer-side `try/except` can't suppress it: the plugin marks the `create` span as errored before the exception reaches the consumer, and a second `/users` hit always produces a second segment. The only robust fix is to **prevent the duplicate request**.

#386 surfaced this by moving happybase to **1.3.0 / thriftpy2 0.6.0** on 3.12+, pushing cold-create latency right around the 5s line (hence "only 3.12", and it recurs on reruns). The floating `harisekhon/hbase:latest` image makes the timing env-dependent.

**Fix:** bump the happybase probe timeout to `60s` so the first reachable request completes cleanly and the readiness loop breaks on a single 200 response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)