### PR TITLE
fix(ci): pin docker/* actions to ASF-approved SHAs in publish-docker

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -55,14 +55,14 @@ jobs:
             echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
           fi
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Build and push docker image
         run: make push-image -j 5


### PR DESCRIPTION
### Problem

The `publish-docker` workflow fails at startup (`startup_failure`) on every push to `master` — the ASF GitHub Actions allow-list rejects its three third-party docker actions because they are pinned to floating `@v3` tags instead of approved SHAs:

- `docker/login-action@v3`
- `docker/setup-qemu-action@v3`
- `docker/setup-buildx-action@v3`

This workflow runs **only** on `push` to `master` and on `release` — never on `pull_request` — so the rejection does not appear in PR CI. It first surfaced when #388 merged: [run 28161685059](https://github.com/apache/skywalking-python/actions/runs/28161685059).

### Fix

Pin all three to the SHAs already approved on the [ASF allow-list](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) and used consistently across the sibling ASF SkyWalking repos:

| Action | Pin |
|--------|-----|
| `docker/login-action` | `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` # v4.2.0 |
| `docker/setup-qemu-action` | `06116385d9baf250c9f4dcb4858b16962ea869c3` # v4.1.0 |
| `docker/setup-buildx-action` | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` # v4.1.0 |

### Audit

Swept every `uses:` across all workflows. After this change, **all** third-party actions are SHA-pinned and on the allow-list (`dorny/paths-filter` was fixed in #405; `tcort/github-action-markdown-link-check` was already pinned). `actions/*` and `apache/*` are auto-allowed. No other floating third-party tags remain.

> Note: `startup_failure` means the workflow was rejected before any job ran, so there is no log to re-run — this must be fixed by editing the pins (as done here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)